### PR TITLE
debugging to get measles spatPomp working with genkf

### DIFF
--- a/R/genkf.R
+++ b/R/genkf.R
@@ -112,11 +112,11 @@ genkf.internal <- function (object,
   # object <- pomp(object,...,verbose=verbose)
 
   if (pomp:::undefined(object@rprocess))
-    pStop_(paste(sQuote(c("rprocess")),collapse=", ")," is a needed basic component.")
+    pomp:::pStop_(paste(sQuote(c("rprocess")),collapse=", ")," is a needed basic component.")
   if (pomp:::undefined(object@unit_emeasure))
-    pStop_(paste(sQuote(c("unit_emeasure")),collapse=", ")," is a needed basic component.")
+    pomp:::pStop_(paste(sQuote(c("unit_emeasure")),collapse=", ")," is a needed basic component.")
   if (pomp:::undefined(object@unit_vmeasure))
-    pStop_(paste(sQuote(c("unit_vmeasure")),collapse=", ")," is a needed basic component.")
+    pomp:::pStop_(paste(sQuote(c("unit_vmeasure")),collapse=", ")," is a needed basic component.")
 
   Np <- as.integer(Np)
   #R <- as.matrix(R)
@@ -179,7 +179,7 @@ genkf.internal <- function (object,
     sqrtR <- tryCatch(
       t(chol(R)),                     # t(sqrtR)%*%sqrtR == R
       error = function (e) {
-        pStop_("degenerate ",sQuote("R"), "at time ", squote(k), ": ",conditionMessage(e))
+        pomp:::pStop_("degenerate ",sQuote("R"), "at time ", sQuote(k), ": ",conditionMessage(e))
       }
     )
     X <- X[,,1]

--- a/R/measles.R
+++ b/R/measles.R
@@ -144,8 +144,16 @@ measles_rprocess <- Csnippet('
   // transmission rate
   beta = R0*(gamma+mu)*seas;
 
-  // pre-computing this saves substantial time
   for (u = 0 ; u < U ; u++) {
+    // needed for the Ensemble Kalman filter
+    // or other methods making real-valued perturbations to the state
+    // reulermultinom requires integer-valued double type for states
+    S[u] = S[u]>0 ? floor(S[u]) : 0;
+    E[u] = E[u]>0 ? floor(E[u]) : 0;
+    I[u] = I[u]>0 ? floor(I[u]) : 0;
+    R[u] = R[u]>0 ? floor(R[u]) : 0;
+
+    // pre-computing this saves substantial time
     powVec[u] = pow(I[u]/pop[u],alpha);
   }
 
@@ -180,6 +188,7 @@ measles_rprocess <- Csnippet('
 
     // Poisson births
     births = rpois(br*dt);
+
 
     // transitions between classes
     reulermultinom(2,S[u],&rate[0],dt,&trans[0]);


### PR DESCRIPTION
1. measles.R    // needed for the Ensemble Kalman filter
    // or other methods making real-valued perturbations to the state
    // reulermultinom requires integer-valued double type for states
    S[u] = S[u]>0 ? floor(S[u]) : 0;
    E[u] = E[u]>0 ? floor(E[u]) : 0;
    I[u] = I[u]>0 ? floor(I[u]) : 0;
    R[u] = R[u]>0 ? floor(R[u]) : 0;

2. genkf.R  pStop_ -> pomp:::pStop_
