### PR TITLE
update for pomp v4

### DIFF
--- a/tests/testthat/test_bm_methods.R
+++ b/tests/testthat/test_bm_methods.R
@@ -33,27 +33,25 @@ for(u in 1:U) {
 
 # compute the true log-likelihood
 rootQ = coef(bm_obj)["rho"]^dmat * coef(bm_obj)["sigma"]
-loglik_true <- pomp:::kalmanFilter(
-  t=1:N,
-  y=obs(bm_obj),
+loglik_true <- kalmanFilter(
+  bm_obj,
   X0=rinit(bm_obj),
   A= diag(length(unit_names(bm_obj))),
   Q=rootQ%*%rootQ,
   C=diag(1,nrow=nrow(dmat)),
   R=diag(coef(bm_obj)["tau"]^2, nrow=nrow(dmat))
-)$loglik
+)$logLik
 
 fun_to_optim <- function(cf){
   rootQ = cf["rho"]^dmat * cf["sigma"]
-  -pomp:::kalmanFilter(
-    t=1:N,
-    y=obs(bm_obj),
+  -kalmanFilter(
+    bm_obj,
     X0=rinit(bm_obj),
     A=diag(length(unit_names(bm_obj))),
     Q=rootQ%*%rootQ,
     C=diag(1,nrow=nrow(dmat)),
     R=diag(cf["tau"]^2, nrow=nrow(dmat))
-  )$loglik
+  )$logLik
 }
 mle <- optim(coef(bm_obj), fun_to_optim)
 kfll_mle <- -mle$value


### PR DESCRIPTION
@kidusasfaw: this pull request makes changes in anticipation of the release of **pomp** version 4.  In particular, I am exporting the `kalmanFilter` function in that release, with some changes to its interface.  This pull request merely makes your test conform to the new syntax.

I don't anticipate making the next CRAN release (v 4.1) for several weeks.  I will coordinate with you when I do, so that you can ensure that **spatPomp** doesn't break.