### PR TITLE
resolve NOTEs in R CMD CHECK --as-cran

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: spatPomp
 Type: Package
 Title: Inference for Spatiotemporal Partially Observed Markov Processes
-Version: 0.28.0.0
-Date: 2021-09-04
+Version: 0.29.0.0
+Date: 2022-01-12
 Authors@R: c(person("Kidus", "Asfaw", email = "kasfaw@umich.edu", role = c("aut", "cre")),
              person("Aaron A.", "King", email = "kingaa@umich.edu", role = c("aut")),
              person("Edward", "Ionides", email = "ionides@umich.edu", role = c("aut")),
@@ -15,10 +15,10 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Contact: kasfaw at umich dot edu
-Depends: pomp (>= 3.3), R(>= 4.0.0), methods
+Depends: pomp (>= 4.1), R(>= 4.0.0), methods
 LinkingTo: pomp
 Suggests: testthat, doParallel (>= 1.0.11), parallel
-Imports: foreach, dplyr, tidyr, stringr, ggplot2, abind, rlang, magrittr
+Imports: foreach, dplyr, tidyr, stringr, abind, rlang, magrittr
 Collate:
     'spatPomp_class.R'
     'abf.R'

--- a/R/abf.R
+++ b/R/abf.R
@@ -86,22 +86,23 @@ setClass(
     loglik=as.double(NA)
   )
 )
+
 abf_internal <- function (object, Np, nbhd, tol, ..., verbose, .gnsi = TRUE) {
   ep <- paste0("in ",sQuote("abf"),": ")
   p_object <- pomp(object,...,verbose=verbose)
   object <- new("spatPomp",p_object,
-                unit_covarnames = object@unit_covarnames,
-                shared_covarnames = object@shared_covarnames,
-                runit_measure = object@runit_measure,
-                dunit_measure = object@dunit_measure,
-                eunit_measure = object@eunit_measure,
-                munit_measure = object@munit_measure,
-                vunit_measure = object@vunit_measure,
-                unit_names=object@unit_names,
-                unitname=object@unitname,
-                unit_statenames=object@unit_statenames,
-                unit_obsnames = object@unit_obsnames,
-                unit_accumvars = object@unit_accumvars)
+    unit_covarnames = object@unit_covarnames,
+    shared_covarnames = object@shared_covarnames,
+    runit_measure = object@runit_measure,
+    dunit_measure = object@dunit_measure,
+    eunit_measure = object@eunit_measure,
+    munit_measure = object@munit_measure,
+    vunit_measure = object@vunit_measure,
+    unit_names=object@unit_names,
+    unitname=object@unitname,
+    unit_statenames=object@unit_statenames,
+    unit_obsnames = object@unit_obsnames,
+    unit_accumvars = object@unit_accumvars)
   params <- coef(object)
   verbose = FALSE
   pompLoad(object,verbose)
@@ -128,7 +129,7 @@ abf_internal <- function (object, Np, nbhd, tol, ..., verbose, .gnsi = TRUE) {
       vapply(seq.int(from=0,to=ntimes,by=1),Np,numeric(1)),
       error = function (e) {
         stop(ep,"if ",sQuote("Np")," is a function, ",
-             "it must return a single positive integer",call.=FALSE)
+          "it must return a single positive integer",call.=FALSE)
       }
     )
   }
@@ -144,12 +145,11 @@ abf_internal <- function (object, Np, nbhd, tol, ..., verbose, .gnsi = TRUE) {
   if (is.matrix(params)) {
     if (!all(Np==ncol(params)))
       stop(ep,"when ",sQuote("params")," is provided as a matrix, do not specify ",
-           sQuote("Np"),"!",call.=FALSE)
+        sQuote("Np"),"!",call.=FALSE)
   }
 
-  if (NCOL(params)==1) {        # there is only one parameter vector
-    one.par <- TRUE
-    coef(object) <- params     # set params slot to the parameters
+  if (NCOL(params)==1) {   ## there is only one parameter vector
+    coef(object) <- params ## set params slot to the parameters
     params <- as.matrix(params)
   }
 
@@ -159,20 +159,13 @@ abf_internal <- function (object, Np, nbhd, tol, ..., verbose, .gnsi = TRUE) {
 
   ## returns an nvars by nsim matrix
   init.x <- rinit(object,params=params,nsim=Np[1L],.gnsi=gnsi)
-  statenames <- rownames(init.x)
-  nvars <- nrow(init.x)
   x <- init.x
 
-  loglik <- rep(NA,ntimes)
-
-  # create array to store weights across time
+  ## create array to store weights across time
   log_cond_densities <- array(data = numeric(0), dim=c(nunits,Np[1L],ntimes))
   dimnames(log_cond_densities) <- list(unit = 1:nunits, rep = 1:Np[1L], time = 1:ntimes)
   for (nt in seq_len(ntimes)) { ## main loop
     ## advance the state variables according to the process model
-    # if(nt == 3){
-    #   print("stop")
-    # }
     X <- tryCatch(
       rprocess(
         object,
@@ -184,7 +177,7 @@ abf_internal <- function (object, Np, nbhd, tol, ..., verbose, .gnsi = TRUE) {
       ),
       error = function (e) {
         stop(ep,"process simulation error: ",
-             conditionMessage(e),call.=FALSE)
+          conditionMessage(e),call.=FALSE)
       }
     )
 
@@ -201,24 +194,24 @@ abf_internal <- function (object, Np, nbhd, tol, ..., verbose, .gnsi = TRUE) {
       ),
       error = function (e) {
         stop(ep,"error in calculation of weights: ",
-             conditionMessage(e),call.=FALSE)
+          conditionMessage(e),call.=FALSE)
       }
     )
-    #weights[weights == 0] <- tol
+                                        #weights[weights == 0] <- tol
     log_cond_densities[,,nt] <- log_weights[,,1]
     log_resamp_weights <- apply(log_weights[,,1,drop=FALSE], 2, function(x) sum(x))
     max_log_resamp_weights <- max(log_resamp_weights)
-    # if any particle's resampling weight is zero replace by tolerance
+                                        # if any particle's resampling weight is zero replace by tolerance
     if(all(is.infinite(log_resamp_weights))) log_resamp_weights <- rep(log(tol), Np[1L])
     else log_resamp_weights <- log_resamp_weights - max_log_resamp_weights
     resamp_weights <- exp(log_resamp_weights)
-    #if(all(resamp_weights == 0)) resamp_weights <- rep(tol, Np[1L])
+                                        #if(all(resamp_weights == 0)) resamp_weights <- rep(tol, Np[1L])
     gnsi <- FALSE
 
     ## do resampling if filtering has not failed
     xx <- tryCatch(
       .Call(
-        "abf_computations",
+        abf_computations,
         x=X,
         params=params,
         Np=Np[nt+1],
@@ -237,30 +230,30 @@ abf_internal <- function (object, Np, nbhd, tol, ..., verbose, .gnsi = TRUE) {
       cat("abf timestep",nt,"of",ntimes,"finished\n")
   } ## end of main loop
 
-  # compute locally combined pred. weights for each time, unit and particle
-  log_loc_comb_pred_weights = array(data = numeric(0), dim=c(nunits,Np[1L], ntimes))
-  log_wm_times_wp_avg = array(data = numeric(0), dim = c(nunits, ntimes))
-  log_wp_avg = array(data = numeric(0), dim = c(nunits, ntimes))
+                                        # compute locally combined pred. weights for each time, unit and particle
+  log_loc_comb_pred_weights <- array(data = numeric(0), dim=c(nunits,Np[1L], ntimes))
+  log_wm_times_wp_avg <- array(data = numeric(0), dim = c(nunits, ntimes))
+  log_wp_avg <- array(data = numeric(0), dim = c(nunits, ntimes))
   for (nt in seq_len(ntimes)){
-      for (unit in seq_len(nunits)){
-          full_nbhd <- nbhd(object, time = nt, unit = unit)
-          log_prod_cond_dens_nt  <- rep(0, Np[1])
-          if(length(full_nbhd) > 0) log_prod_cond_dens_not_nt <- matrix(0, Np[1], max(1,nt-min(sapply(full_nbhd,'[[',2))))
-          else log_prod_cond_dens_not_nt <- matrix(0,Np[1],0)
-          for (neighbor in full_nbhd){
-              neighbor_u <- neighbor[1]
-              neighbor_n <- neighbor[2]
-              if (neighbor_n == nt)
-                  log_prod_cond_dens_nt  <- log_prod_cond_dens_nt + log_cond_densities[neighbor_u, ,neighbor_n]
-              else
-                  log_prod_cond_dens_not_nt[, nt-neighbor_n] <- log_prod_cond_dens_not_nt[, nt-neighbor_n] + log_cond_densities[neighbor_u, ,neighbor_n]
-          }
-          log_loc_comb_pred_weights[unit, ,nt]  <- sum(apply(log_prod_cond_dens_not_nt, 2, logmeanexp)) + log_prod_cond_dens_nt
-          # log_loc_comb_pred_weights[unit, ,nt] <- rowSums(log_prod_cond_dens_not_nt) + log_prod_cond_dens_nt
+    for (unit in seq_len(nunits)){
+      full_nbhd <- nbhd(object, time = nt, unit = unit)
+      log_prod_cond_dens_nt  <- rep(0, Np[1])
+      if(length(full_nbhd) > 0) log_prod_cond_dens_not_nt <- matrix(0, Np[1], max(1,nt-min(sapply(full_nbhd,'[[',2))))
+      else log_prod_cond_dens_not_nt <- matrix(0,Np[1],0)
+      for (neighbor in full_nbhd){
+        neighbor_u <- neighbor[1]
+        neighbor_n <- neighbor[2]
+        if (neighbor_n == nt)
+          log_prod_cond_dens_nt  <- log_prod_cond_dens_nt + log_cond_densities[neighbor_u, ,neighbor_n]
+        else
+          log_prod_cond_dens_not_nt[, nt-neighbor_n] <- log_prod_cond_dens_not_nt[, nt-neighbor_n] + log_cond_densities[neighbor_u, ,neighbor_n]
       }
+      log_loc_comb_pred_weights[unit, ,nt]  <- sum(apply(log_prod_cond_dens_not_nt, 2, logmeanexp)) + log_prod_cond_dens_nt
+                                        # log_loc_comb_pred_weights[unit, ,nt] <- rowSums(log_prod_cond_dens_not_nt) + log_prod_cond_dens_nt
+    }
   }
-  log_wm_times_wp_avg = apply(log_loc_comb_pred_weights + log_cond_densities, c(1,3), FUN = logmeanexp)
-  log_wp_avg = apply(log_loc_comb_pred_weights, c(1,3), FUN = logmeanexp)
+  log_wm_times_wp_avg <- apply(log_loc_comb_pred_weights + log_cond_densities, c(1,3), FUN = logmeanexp)
+  log_wp_avg <- apply(log_loc_comb_pred_weights, c(1,3), FUN = logmeanexp)
   pompUnload(object,verbose=verbose)
   new(
     "adapted_replicate",
@@ -281,73 +274,71 @@ setMethod(
   "abf",
   signature=signature(object="spatPomp"),
   function (object, Nrep, Np, nbhd,
-           tol = 1e-300,
-           ..., verbose=getOption("verbose",FALSE)) {
+    tol = 1e-300,
+    ..., verbose=getOption("verbose",FALSE)) {
     if(missing(nbhd)){
-     nbhd <- function(object, unit, time){
-       nbhd_list = list()
-       if(time>1) nbhd_list <- c(nbhd_list, list(c(unit, time-1)))
-       if(unit>1) nbhd_list <- c(nbhd_list, list(c(unit-1, time)))
-       return(nbhd_list)
-     }
+      nbhd <- function(object, unit, time){
+        nbhd_list <- list()
+        if(time>1) nbhd_list <- c(nbhd_list, list(c(unit, time-1)))
+        if(unit>1) nbhd_list <- c(nbhd_list, list(c(unit-1, time)))
+        return(nbhd_list)
+      }
     }
-   ## single thread for testing
-   mult_rep_output <- list()
-   # for(i in 1:Nrep){
-   #   mult_rep_output <- c(mult_rep_output,
-   #                        abf_internal(
-   #                          object=object,
-   #                          Np=Np,
-   #                          nbhd = nbhd,
-   #                          tol=tol,
-   #                          ...,
-   #                          verbose=verbose)
-   #                        )
-   # }
-   ## end single thread for testing
-   ## begin multi-thread code
-   i <- 1
-   mcopts <- list(set.seed=TRUE)
-   mult_rep_output <- foreach::foreach(i=1:Nrep,
-       .packages=c("pomp","spatPomp"),
-       .options.multicore=mcopts) %dopar%  spatPomp:::abf_internal(
-     object=object,
-     Np=Np,
-     nbhd=nbhd,
-     tol=tol,
-     ...,
-     verbose=verbose
-     )
-   ntimes = length(time(object))
-   nunits = length(unit_names(object))
-   rep_mp_sums = array(data = numeric(0), dim = c(nunits,ntimes))
-   rep_p_sums = array(data = numeric(0), dim = c(nunits, ntimes))
-   cond_loglik <- foreach::foreach(i=seq_len(nunits),
-                    .combine = 'rbind',
-                    .packages=c("pomp", "spatPomp"),
-                    .options.multicore=mcopts) %dopar%
-                    {
-                      cond_loglik_u <- array(data = numeric(0), dim=c(ntimes))
-                      for (n in seq_len(ntimes)){
-                        log_mp_sum = logmeanexp(vapply(mult_rep_output,
-                                                       FUN = function(rep_output) return(rep_output@log_wm_times_wp_avg[i,n]),
-                                                       FUN.VALUE = 1.0))
-                        log_p_sum = logmeanexp(vapply(mult_rep_output,
-                                                      FUN = function(rep_output) return(rep_output@log_wp_avg[i,n]),
-                                                      FUN.VALUE = 1.0))
-                        cond_loglik_u[n] = log_mp_sum - log_p_sum
-                      }
-                      cond_loglik_u
-                    }
-   # end multi-threaded code
-   new(
+    ## single thread for testing
+    mult_rep_output <- list()
+    ## for(i in 1:Nrep){
+    ##   mult_rep_output <- c(mult_rep_output,
+    ##                        abf_internal(
+    ##                          object=object,
+    ##                          Np=Np,
+    ##                          nbhd = nbhd,
+    ##                          tol=tol,
+    ##                          ...,
+    ##                          verbose=verbose)
+    ##                        )
+    ## }
+    ## end single thread for testing
+    ## begin multi-thread code
+    i <- 1
+    mcopts <- list(set.seed=TRUE)
+    mult_rep_output <- foreach::foreach(i=1:Nrep,
+      .packages=c("pomp","spatPomp"),
+      .options.multicore=mcopts) %dopar%  spatPomp:::abf_internal(
+                                                       object=object,
+                                                       Np=Np,
+                                                       nbhd=nbhd,
+                                                       tol=tol,
+                                                       ...,
+                                                       verbose=verbose
+                                                     )
+    ntimes <- length(time(object))
+    nunits <- length(unit_names(object))
+    cond_loglik <- foreach::foreach(i=seq_len(nunits),
+      .combine = 'rbind',
+      .packages=c("pomp", "spatPomp"),
+      .options.multicore=mcopts) %dopar%
+      {
+        cond_loglik_u <- array(data = numeric(0), dim=c(ntimes))
+        for (n in seq_len(ntimes)){
+          log_mp_sum <- logmeanexp(vapply(mult_rep_output,
+            FUN = function(rep_output) return(rep_output@log_wm_times_wp_avg[i,n]),
+            FUN.VALUE = 1.0))
+          log_p_sum <- logmeanexp(vapply(mult_rep_output,
+            FUN = function(rep_output) return(rep_output@log_wp_avg[i,n]),
+            FUN.VALUE = 1.0))
+          cond_loglik_u[n] <- log_mp_sum - log_p_sum
+        }
+        cond_loglik_u
+      }
+                                        # end multi-threaded code
+    new(
       "abfd_spatPomp",
       object,
       Np=as.integer(Np),
       tol=tol,
       cond_loglik=cond_loglik,
       loglik=sum(cond_loglik)
-     )
+    )
   }
 )
 
@@ -359,20 +350,20 @@ setMethod(
   "abf",
   signature=signature(object="abfd_spatPomp"),
   function (object, Nrep, Np, nbhd,
-            tol=1e-300,
-            ...,
-            verbose = getOption("verbose", FALSE)) {
+    tol=1e-300,
+    ...,
+    verbose = getOption("verbose", FALSE)) {
     if (missing(Np)) Np <- object@Np
     if (missing(tol)) tol <- object@tol
     if (missing(Nrep)) Nrep <- object@Nrep
     if (missing(nbhd)) nbhd <- object@nbhd
 
     abf(as(object,"spatPomp"),
-           Np=Np,
-           Nrep=Nrep,
-           nbhd=nbhd,
-           tol=tol,
-           ...)
+      Np=Np,
+      Nrep=Nrep,
+      nbhd=nbhd,
+      tol=tol,
+      ...)
   }
 )
 

--- a/R/abfir.R
+++ b/R/abfir.R
@@ -73,23 +73,24 @@ setClass(
     nbhd=function(){}
   )
 )
+
 abfir_internal <- function (object, Np, nbhd,
-      Ninter, tol, ..., verbose, .gnsi = TRUE) {
+  Ninter, tol, ..., verbose, .gnsi = TRUE) {
   ep <- paste0("in ",sQuote("abfir"),": ")
   p_object <- pomp(object,...,verbose=verbose)
   object <- new("spatPomp",p_object,
-                unit_covarnames = object@unit_covarnames,
-                shared_covarnames = object@shared_covarnames,
-                runit_measure = object@runit_measure,
-                dunit_measure = object@dunit_measure,
-                eunit_measure = object@eunit_measure,
-                munit_measure = object@munit_measure,
-                vunit_measure = object@vunit_measure,
-                unit_names=object@unit_names,
-                unitname=object@unitname,
-                unit_statenames=object@unit_statenames,
-                unit_obsnames = object@unit_obsnames,
-                unit_accumvars = object@unit_accumvars)
+    unit_covarnames = object@unit_covarnames,
+    shared_covarnames = object@shared_covarnames,
+    runit_measure = object@runit_measure,
+    dunit_measure = object@dunit_measure,
+    eunit_measure = object@eunit_measure,
+    munit_measure = object@munit_measure,
+    vunit_measure = object@vunit_measure,
+    unit_names=object@unit_names,
+    unitname=object@unitname,
+    unit_statenames=object@unit_statenames,
+    unit_obsnames = object@unit_obsnames,
+    unit_accumvars = object@unit_accumvars)
   params <- coef(object)
   verbose = FALSE
   pompLoad(object,verbose=verbose)
@@ -123,7 +124,6 @@ abfir_internal <- function (object, Np, nbhd,
   xas <- as.numeric(x_init) # adapted simulation state vector
   znames <- object@accumvars
 
-  loglik <- rep(NA,N)
   log_cond_densities <- array(data = numeric(0), dim=c(U,Np,N))
   dimnames(log_cond_densities) <- list(unit = 1:U, rep = 1:Np, time = 1:N)
 
@@ -151,13 +151,13 @@ abfir_internal <- function (object, Np, nbhd,
     dim(xg_with_rep) <- c(dim(xg_with_rep)[1],dim(xg_with_rep)[2],1)
     dimnames(xg_with_rep) <- list(states = rownames(xg_2dim))
     xx <- tryCatch(
-      .Call('do_fcst_samp_var',
-            object=object,
-            X=xg_with_rep,
-            Np = as.integer(Np),
-            times=times[n+1],
-            params=params,
-            gnsi=TRUE),
+      .Call(do_fcst_samp_var,
+        object=object,
+        X=xg_with_rep,
+        Np = as.integer(Np),
+        times=times[n+1],
+        params=params,
+        gnsi=TRUE),
       error = function (e) {
         stop(ep,conditionMessage(e),call.=FALSE) # nocov
       }
@@ -177,7 +177,7 @@ abfir_internal <- function (object, Np, nbhd,
       ),
       error = function (e) {
         stop(ep,"error in calculation of weights: ",
-             conditionMessage(e),call.=FALSE)
+          conditionMessage(e),call.=FALSE)
       }
     )
 
@@ -194,18 +194,18 @@ abfir_internal <- function (object, Np, nbhd,
       if(s < Ninter){
         skel <- tryCatch(
           pomp::flow(object,
-                     x0=xp[,,1],
-                     t0=tt[s+1],
-                     params=param_matrix,
-                     times = times[n + 1],
-                     ...),
+            x0=xp[,,1],
+            t0=tt[s+1],
+            params=param_matrix,
+            times = times[n + 1],
+            ...),
           error = function (e) {
             pomp::flow(object,
-                       x0=xp[,,1],
-                       t0=tt[s+1],params=param_matrix,
-                       times = times[n + 1],
-                       method='adams')
-            }
+              x0=xp[,,1],
+              t0=tt[s+1],params=param_matrix,
+              times = times[n + 1],
+              method='adams')
+          }
         )
         if(length(znames) > 0){
           skel.lookahead1.znames <- skel[znames,,1,drop=FALSE]
@@ -216,13 +216,13 @@ abfir_internal <- function (object, Np, nbhd,
         skel <- xp
       }
       meas_var_skel <- tryCatch(
-        .Call('do_theta_to_v',
-              object=object,
-              X=skel,
-              Np = as.integer(Np[1]),
-              times=times[n+1],
-              params=params,
-              gnsi=TRUE),
+        .Call(do_theta_to_v,
+          object=object,
+          X=skel,
+          Np = as.integer(Np[1]),
+          times=times[n+1],
+          params=params,
+          gnsi=TRUE),
         error = function (e) {
           stop(ep,conditionMessage(e),call.=FALSE) # nocov
         }
@@ -234,14 +234,14 @@ abfir_internal <- function (object, Np, nbhd,
       array.params <- array(params, dim = c(length(params), length(unit_names(object)), Np, 1), dimnames = list(params = names(params)))
 
       mmp <- tryCatch(
-        .Call('do_v_to_theta',
-              object=object,
-              X=skel,
-              vc=inflated_var,
-              Np = as.integer(Np[1]),
-              times=times[n+1],
-              params=array.params,
-              gnsi=TRUE),
+        .Call(do_v_to_theta,
+          object=object,
+          X=skel,
+          vc=inflated_var,
+          Np = as.integer(Np[1]),
+          times=times[n+1],
+          params=array.params,
+          gnsi=TRUE),
         error = function (e) {
           stop(ep,conditionMessage(e),call.=FALSE) # nocov
         }
@@ -268,7 +268,7 @@ abfir_internal <- function (object, Np, nbhd,
         weights <- exp(log_gp - log_gf)
         gnsi <- FALSE
         xx <- tryCatch(
-          .Call('abfir_resample', xp, Np, weights, log_gp, tol),
+          .Call(abfir_resample, xp, Np, weights, log_gp, tol),
           error = function (e) stop(ep,conditionMessage(e),call.=FALSE)
         )
         xf <- xx$states
@@ -280,7 +280,7 @@ abfir_internal <- function (object, Np, nbhd,
       }
 
     }
-    # resample down to one particle, making Np copies of, say, particle #1.
+                                        # resample down to one particle, making Np copies of, say, particle #1.
     xas <- xf[,1]
 
     if (verbose && (n%%5==0)) cat("abfir timestep",n,"of",N,"finished\n")
@@ -290,21 +290,21 @@ abfir_internal <- function (object, Np, nbhd,
   log_wm_times_wp_avg = array(data = numeric(0), dim = c(U, N))
   log_wp_avg = array(data = numeric(0), dim = c(U, N))
   for (n in seq_len(N)){
-      for (u in seq_len(U)){
-          full_nbhd <- nbhd(object, time = n, unit = u)
-          log_prod_cond_dens_nt  <- rep(0, Np)
-          if(length(full_nbhd) > 0) log_prod_cond_dens_not_nt <- matrix(0, Np[1], max(1,n-min(sapply(full_nbhd,'[[',2))))
-          else log_prod_cond_dens_not_nt <- matrix(0,Np[1],0)
-          for (neighbor in full_nbhd){
-              neighbor_u <- neighbor[1]
-              neighbor_n <- neighbor[2]
-              if (neighbor_n == n)
-                  log_prod_cond_dens_nt  <- log_prod_cond_dens_nt + log_cond_densities[neighbor_u, ,neighbor_n]
-              else
-                  log_prod_cond_dens_not_nt[, n-neighbor_n] <- log_prod_cond_dens_not_nt[, n-neighbor_n] + log_cond_densities[neighbor_u, ,neighbor_n]
-          }
-          log_loc_comb_pred_weights[u,,n]  <- sum(apply(log_prod_cond_dens_not_nt, 2, logmeanexp)) + log_prod_cond_dens_nt
+    for (u in seq_len(U)){
+      full_nbhd <- nbhd(object, time = n, unit = u)
+      log_prod_cond_dens_nt  <- rep(0, Np)
+      if(length(full_nbhd) > 0) log_prod_cond_dens_not_nt <- matrix(0, Np[1], max(1,n-min(sapply(full_nbhd,'[[',2))))
+      else log_prod_cond_dens_not_nt <- matrix(0,Np[1],0)
+      for (neighbor in full_nbhd){
+        neighbor_u <- neighbor[1]
+        neighbor_n <- neighbor[2]
+        if (neighbor_n == n)
+          log_prod_cond_dens_nt  <- log_prod_cond_dens_nt + log_cond_densities[neighbor_u, ,neighbor_n]
+        else
+          log_prod_cond_dens_not_nt[, n-neighbor_n] <- log_prod_cond_dens_not_nt[, n-neighbor_n] + log_cond_densities[neighbor_u, ,neighbor_n]
       }
+      log_loc_comb_pred_weights[u,,n]  <- sum(apply(log_prod_cond_dens_not_nt, 2, logmeanexp)) + log_prod_cond_dens_nt
+    }
   }
   log_wm_times_wp_avg = apply(log_loc_comb_pred_weights + log_cond_densities, c(1,3), FUN = logmeanexp)
   log_wp_avg = apply(log_loc_comb_pred_weights, c(1,3), FUN = logmeanexp)
@@ -329,64 +329,65 @@ setMethod(
   "abfir",
   signature=signature(object="spatPomp"),
   function (object, Np, Nrep, nbhd,
-            Ninter, tol = (1e-300), ...,
-            verbose=getOption("verbose",FALSE)) {
-  # declare global variable since foreach's u uses non-standard evaluation
-  i <- 1
-  if (missing(Ninter)) Ninter <- length(unit_names(object))
-  if(missing(nbhd)){
-    nbhd <- function(object, unit, time){
-      nbhd_list = list()
-      if(time>1) nbhd_list <- c(nbhd_list, list(c(unit, time-1)))
-      if(unit>1) nbhd_list <- c(nbhd_list, list(c(unit-1, time)))
-      return(nbhd_list)
+    Ninter, tol = (1e-300), ...,
+    verbose=getOption("verbose",FALSE)) {
+                                        # declare global variable since foreach's u uses non-standard evaluation
+    i <- 1
+    if (missing(Ninter)) Ninter <- length(unit_names(object))
+    if(missing(nbhd)){
+      nbhd <- function(object, unit, time){
+        nbhd_list = list()
+        if(time>1) nbhd_list <- c(nbhd_list, list(c(unit, time-1)))
+        if(unit>1) nbhd_list <- c(nbhd_list, list(c(unit-1, time)))
+        return(nbhd_list)
+      }
     }
-  }
-    # set.seed(396658101,kind="L'Ecuyer")
-  # begin single-core
-  # single_rep_output <- spatPomp:::abfir_internal(
-  #   object=object,
-  #   Np=Np,
-  #   nbhd=nbhd,
-  #   Ninter=Ninter,
-  #   tol=tol,
-  #   ...
-  # )
-  # return(single_rep_output)
-  # end single-core
-  mcopts <- list(set.seed=TRUE)
-  mult_rep_output <- foreach::foreach(i=1:Nrep,
-     .packages=c("pomp","spatPomp"),
-     .options.multicore=list(set.seed=TRUE)) %dopar% spatPomp:::abfir_internal(
-       object=object,
-       Np=Np,
-       nbhd=nbhd,
-       Ninter=Ninter,
-       tol=tol,
-       ...,
-       verbose=verbose
-     )
-   # compute sum (over all Nrep) of w_{d,n,i}^{P} for each (d,n)
-   N <- length(object@times)
-   U <- length(unit_names(object))
-   cond_loglik <- foreach::foreach(i=seq_len(U),
-                                   .combine = 'rbind',
-                                   .packages=c("pomp", "spatPomp"),
-                                   .options.multicore=mcopts) %dopar%
-                                   {
-                                     cond_loglik_u <- array(data = numeric(0), dim=c(N))
-                                     for (n in seq_len(N)){
-                                       log_mp_sum = logmeanexp(vapply(mult_rep_output,
-                                                                      FUN = function(rep_output) return(rep_output@log_wm_times_wp_avg[i,n]),
-                                                                      FUN.VALUE = 1.0))
-                                       log_p_sum = logmeanexp(vapply(mult_rep_output,
-                                                                     FUN = function(rep_output) return(rep_output@log_wp_avg[i,n]),
-                                                                     FUN.VALUE = 1.0))
-                                       cond_loglik_u[n] = log_mp_sum - log_p_sum
-                                     }
-                                     cond_loglik_u
-                                   }
-   new(
+    ## set.seed(396658101,kind="L'Ecuyer")
+    ## begin single-core
+    ## single_rep_output <- spatPomp:::abfir_internal(
+    ##   object=object,
+    ##   Np=Np,
+    ##   nbhd=nbhd,
+    ##   Ninter=Ninter,
+    ##   tol=tol,
+    ##   ...
+    ## )
+    ## return(single_rep_output)
+    ## end single-core
+    mcopts <- list(set.seed=TRUE)
+    mult_rep_output <- foreach::foreach(i=1:Nrep,
+      .packages=c("pomp","spatPomp"),
+      .options.multicore=list(set.seed=TRUE)) %dopar%
+      spatPomp:::abfir_internal(
+                   object=object,
+                   Np=Np,
+                   nbhd=nbhd,
+                   Ninter=Ninter,
+                   tol=tol,
+                   ...,
+                   verbose=verbose
+                 )
+    ## compute sum (over all Nrep) of w_{d,n,i}^{P} for each (d,n)
+    N <- length(object@times)
+    U <- length(unit_names(object))
+    cond_loglik <- foreach::foreach(i=seq_len(U),
+      .combine = 'rbind',
+      .packages=c("pomp", "spatPomp"),
+      .options.multicore=mcopts) %dopar%
+      {
+        cond_loglik_u <- array(data = numeric(0), dim=c(N))
+        for (n in seq_len(N)){
+          log_mp_sum = logmeanexp(vapply(mult_rep_output,
+            FUN = function(rep_output) return(rep_output@log_wm_times_wp_avg[i,n]),
+            FUN.VALUE = 1.0))
+          log_p_sum = logmeanexp(vapply(mult_rep_output,
+            FUN = function(rep_output) return(rep_output@log_wp_avg[i,n]),
+            FUN.VALUE = 1.0))
+          cond_loglik_u[n] = log_mp_sum - log_p_sum
+        }
+        cond_loglik_u
+      }
+    new(
       "abfird_spatPomp",
       object,
       Np=as.integer(Np),
@@ -395,7 +396,7 @@ setMethod(
       Ninter = as.integer(Ninter),
       Nrep = as.integer(Nrep),
       nbhd = nbhd
-      )
+    )
   }
 )
 
@@ -407,7 +408,7 @@ setMethod(
   "abfir",
   signature=signature(object="abfird_spatPomp"),
   function (object, Np, Nrep, nbhd,
-            Ninter, tol, ...) {
+    Ninter, tol, ...) {
     if (missing(Np)) Np <- object@Np
     if (missing(tol)) tol <- object@tol
     if (missing(Ninter)) Ninter <- object@Ninter
@@ -415,12 +416,11 @@ setMethod(
     if (missing(nbhd)) nbhd <- object@nbhd
 
     abfir(as(object,"spatPomp"),
-         Np=Np,
-         Ninter=Ninter,
-         Nrep=Nrep,
-         nbhd=nbhd,
-         tol=tol,
-         ...)
+      Np=Np,
+      Ninter=Ninter,
+      Nrep=Nrep,
+      nbhd=nbhd,
+      tol=tol,
+      ...)
   }
 )
-

--- a/R/as_data_frame.R
+++ b/R/as_data_frame.R
@@ -38,7 +38,7 @@ setAs(
     }
     if (length(cnames) > 0) {
       nm <- c(colnames(dat),cnames)
-      y <- .Call('lookup_in_table_spatPomp',from@covar,from@times,PACKAGE = 'spatPomp')
+      y <- .Call(lookup_in_table_spatPomp,from@covar,from@times)
       dat <- cbind(dat,t(y))
       colnames(dat) <- nm
       unit_stateobscovars <- c(unit_stateobscovars, from@unit_covarnames)
@@ -62,7 +62,6 @@ setAs(
       to_gather <- no_time_colnames[-shared_covnames_ix]
     else
       to_gather <- no_time_colnames
-    to_select <- c(timename, unitname, "stateobscovars", "val")
     to_arrange <- rlang::syms(c(timename, unitname, "stateobscovars"))
     to_final_select <- c(timename, unitname, unit_stateobscovars)
     gathered <- dat %>%

--- a/R/bpfilter.R
+++ b/R/bpfilter.R
@@ -111,6 +111,7 @@ setMethod(
      verbose=verbose)
   }
 )
+
 bpfilter.internal <- function (object, Np, block_list,...,verbose, .gnsi = TRUE) {
   ep <- paste0("in ",sQuote("bpfilter"),": ")
   verbose <- as.logical(verbose)
@@ -134,7 +135,6 @@ bpfilter.internal <- function (object, Np, block_list,...,verbose, .gnsi = TRUE)
   gnsi <- as.logical(.gnsi)
   times <- time(object,t0=TRUE)
   ntimes <- length(times)-1
-  nunits <- length(unit_names(object))
   nblocks <- length(block_list)
 
   if (length(Np)==1)
@@ -152,7 +152,6 @@ bpfilter.internal <- function (object, Np, block_list,...,verbose, .gnsi = TRUE)
            sQuote("Np"),"!",call.=FALSE)
   }
   if (NCOL(params)==1) {
-    one.par <- TRUE
     coef(object) <- params
     params <- as.matrix(params)
   }
@@ -163,7 +162,6 @@ bpfilter.internal <- function (object, Np, block_list,...,verbose, .gnsi = TRUE)
   ## returns an nvars by nsim matrix
   init.x <- rinit(object,params=params,nsim=Np[1L],.gnsi=gnsi)
   statenames <- rownames(init.x)
-  nvars <- nrow(init.x)
   x <- init.x
 
   # create array to store weights per particle per block_list

--- a/R/enkf.R
+++ b/R/enkf.R
@@ -91,10 +91,10 @@ setMethod(
   "enkf",
   signature=signature(data="spatPomp"),
   function (data,
-            Np,
-            ..., verbose = getOption("verbose", FALSE)) {
+    Np,
+    ..., verbose = getOption("verbose", FALSE)) {
     tryCatch(
-      sp <- enkf.internal(
+      enkf.internal(
         data,
         Np=Np,
         ...,
@@ -106,24 +106,24 @@ setMethod(
 )
 
 enkf.internal <- function (object,
-                           Np,
-                           ..., verbose) {
+  Np,
+  ..., verbose) {
 
   verbose <- as.logical(verbose)
   p_object <- pomp(object,...,verbose=verbose)
   object <- new("spatPomp",p_object,
-                unit_covarnames = object@unit_covarnames,
-                shared_covarnames = object@shared_covarnames,
-                runit_measure = object@runit_measure,
-                dunit_measure = object@dunit_measure,
-                eunit_measure = object@eunit_measure,
-                munit_measure = object@munit_measure,
-                vunit_measure = object@vunit_measure,
-                unit_names=object@unit_names,
-                unitname=object@unitname,
-                unit_statenames=object@unit_statenames,
-                unit_obsnames = object@unit_obsnames,
-                unit_accumvars = object@unit_accumvars)
+    unit_covarnames = object@unit_covarnames,
+    shared_covarnames = object@shared_covarnames,
+    runit_measure = object@runit_measure,
+    dunit_measure = object@dunit_measure,
+    eunit_measure = object@eunit_measure,
+    munit_measure = object@munit_measure,
+    vunit_measure = object@vunit_measure,
+    unit_names=object@unit_names,
+    unitname=object@unitname,
+    unit_statenames=object@unit_statenames,
+    unit_obsnames = object@unit_obsnames,
+    unit_accumvars = object@unit_accumvars)
 
   if (undefined(object@rprocess))
     pStop_(paste(sQuote(c("rprocess")),collapse=", ")," is a needed basic component.")
@@ -159,30 +159,28 @@ enkf.internal <- function (object,
     ## advance ensemble according to state process
     X <- rprocess(object,x0=X,t0=tt[k],times=tt[k+1],params=params)
 
-    # data
-    yk <- y[,k]
-    # ensemble of forecasts
+                                        # ensemble of forecasts
     Y <- tryCatch(
-      .Call('do_theta_to_e',
-            object=object,
-            X=X,
-            Np = as.integer(Np[1]),
-            times=tt[k+1],
-            params=params,
-            gnsi=TRUE),
+      .Call(do_theta_to_e,
+        object=object,
+        X=X,
+        Np = as.integer(Np[1]),
+        times=tt[k+1],
+        params=params,
+        gnsi=TRUE),
       error = function (e) {
         stop("ep",conditionMessage(e),call.=FALSE) # nocov
       }
     )
-    # variance of artificial noise (i.e. R) computed using vmeasure
+                                        # variance of artificial noise (i.e. R) computed using vmeasure
     meas_var <- tryCatch(
-      .Call('do_theta_to_v',
-            object=object,
-            X=X,
-            Np = as.integer(Np[1]),
-            times=tt[k+1],
-            params=params,
-            gnsi=TRUE),
+      .Call(do_theta_to_v,
+        object=object,
+        X=X,
+        Np = as.integer(Np[1]),
+        times=tt[k+1],
+        params=params,
+        gnsi=TRUE),
       error = function (e) {
         stop("ep",conditionMessage(e),call.=FALSE) # nocov
       }
@@ -199,7 +197,7 @@ enkf.internal <- function (object,
     predMeans[,k] <- pm <- rowMeans(X) # prediction mean
     dim(Y) <- c(length(unit_names(object)), Np[1])
 
-    # forecast mean
+                                        # forecast mean
     ym <- rowMeans(Y)
     X <- X-pm
     Y <- Y-ym
@@ -219,22 +217,19 @@ enkf.internal <- function (object,
     forecast[,k] <- ym
   }
   new("enkfd_spatPomp", object,
-      paramMatrix=array(data=numeric(0),dim=c(0,0)),
-      Np=Np,
-      filter.mean=filterMeans,
-      pred.mean=predMeans,
-      forecast=forecast,
-      cond.logLik=condlogLik,
-      loglik=sum(condlogLik),
-      runit_measure = object@runit_measure,
-      dunit_measure = object@dunit_measure,
-      eunit_measure = object@eunit_measure,
-      vunit_measure = object@vunit_measure,
-      munit_measure = object@munit_measure,
-      unit_names=object@unit_names,
-      unit_statenames=object@unit_statenames,
-      unit_obsnames = object@unit_obsnames)
+    paramMatrix=array(data=numeric(0),dim=c(0,0)),
+    Np=Np,
+    filter.mean=filterMeans,
+    pred.mean=predMeans,
+    forecast=forecast,
+    cond.logLik=condlogLik,
+    loglik=sum(condlogLik),
+    runit_measure = object@runit_measure,
+    dunit_measure = object@dunit_measure,
+    eunit_measure = object@eunit_measure,
+    vunit_measure = object@vunit_measure,
+    munit_measure = object@munit_measure,
+    unit_names=object@unit_names,
+    unit_statenames=object@unit_statenames,
+    unit_obsnames = object@unit_obsnames)
 }
-
-
-

--- a/R/eunit_measure.R
+++ b/R/eunit_measure.R
@@ -39,7 +39,7 @@ setMethod(
     pompLoad(object)
     storage.mode(x) <- "double"
     storage.mode(params) <- "double"
-    out <- .Call('do_theta_to_e',
+    out <- .Call(do_theta_to_e,
                  object=object,
                  X=x,
                  Np = as.integer(Np),

--- a/R/ienkf.R
+++ b/R/ienkf.R
@@ -45,10 +45,10 @@ setClass(
   "ienkfd_spatPomp",
   contains="enkfd_spatPomp",
   slots=c(Nenkf = 'integer',
-          rw.sd = 'matrix',
-          cooling.type = 'character',
-          cooling.fraction.50 = 'numeric',
-          traces = 'matrix'
+    rw.sd = 'matrix',
+    cooling.type = 'character',
+    cooling.fraction.50 = 'numeric',
+    traces = 'matrix'
   )
 )
 
@@ -75,10 +75,10 @@ setMethod(
   "ienkf",
   signature=signature(data="spatPomp"),
   definition=function (data,
-                       Nenkf = 1, rw.sd,
-                       cooling.type = c("geometric", "hyperbolic"), cooling.fraction.50,
-                       Np,
-                       ..., verbose = getOption("verbose", FALSE)) {
+    Nenkf = 1, rw.sd,
+    cooling.type = c("geometric", "hyperbolic"), cooling.fraction.50,
+    Np,
+    ..., verbose = getOption("verbose", FALSE)) {
     tryCatch(
       ienkf.internal(
         data,
@@ -96,26 +96,26 @@ setMethod(
 )
 
 ienkf.internal <- function (object, Nenkf, rw.sd,
-                           cooling.type, cooling.fraction.50,
-                           Np,
-                           ..., verbose,
-                           .ndone = 0L, .indices = integer(0), .paramMatrix = NULL,
-                           .gnsi = TRUE) {
+  cooling.type, cooling.fraction.50,
+  Np,
+  ..., verbose,
+  .ndone = 0L, .indices = integer(0), .paramMatrix = NULL,
+  .gnsi = TRUE) {
 
   verbose <- as.logical(verbose)
   p_object <- pomp(object,...,verbose=verbose)
   object <- new("spatPomp",p_object,
-                unit_covarnames = object@unit_covarnames,
-                shared_covarnames = object@shared_covarnames,
-                runit_measure = object@runit_measure,
-                dunit_measure = object@dunit_measure,
-                eunit_measure = object@eunit_measure,
-                munit_measure = object@munit_measure,
-                vunit_measure = object@vunit_measure,
-                unit_names=object@unit_names,
-                unitname=object@unitname,
-                unit_statenames=object@unit_statenames,
-                unit_obsnames = object@unit_obsnames)
+    unit_covarnames = object@unit_covarnames,
+    shared_covarnames = object@shared_covarnames,
+    runit_measure = object@runit_measure,
+    dunit_measure = object@dunit_measure,
+    eunit_measure = object@eunit_measure,
+    munit_measure = object@munit_measure,
+    vunit_measure = object@vunit_measure,
+    unit_names=object@unit_names,
+    unitname=object@unitname,
+    unit_statenames=object@unit_statenames,
+    unit_obsnames = object@unit_obsnames)
 
   if (undefined(object@rprocess) || undefined(object@eunit_measure) || undefined(object@vunit_measure))
     pStop_(paste(sQuote(c("rprocess","eunit_measure","vunit_measure")),collapse=", ")," are needed basic components.")
@@ -132,13 +132,11 @@ ienkf.internal <- function (object, Nenkf, rw.sd,
     start <- apply(.paramMatrix,1L,mean)
   }
 
-  ntimes <- length(time(object))
-
   if (is.null(Np)) {
     pStop_(sQuote("Np")," must be specified.")
   }  else if (!is.numeric(Np)) {
     pStop_(sQuote("Np"),
-           " must be a number, a vector of numbers, or a function.")
+      " must be a number, a vector of numbers, or a function.")
   }
 
   Np <- as.integer(Np)
@@ -150,8 +148,8 @@ ienkf.internal <- function (object, Nenkf, rw.sd,
   if (missing(cooling.fraction.50))
     pStop_(sQuote("cooling.fraction.50")," is a required argument.")
   if (length(cooling.fraction.50) != 1 || !is.numeric(cooling.fraction.50) ||
-      !is.finite(cooling.fraction.50) || cooling.fraction.50 <= 0 ||
-      cooling.fraction.50 > 1)
+        !is.finite(cooling.fraction.50) || cooling.fraction.50 <= 0 ||
+          cooling.fraction.50 > 1)
     pStop_(sQuote("cooling.fraction.50")," must be in (0,1].")
   cooling.fraction.50 <- as.numeric(cooling.fraction.50)
 
@@ -163,21 +161,21 @@ ienkf.internal <- function (object, Nenkf, rw.sd,
 
   if (is.null(.paramMatrix)) {
     paramMatrix <- array(data=start,dim=c(length(start),Np),
-                         dimnames=list(variable=names(start),rep=NULL))
+      dimnames=list(variable=names(start),rep=NULL))
   } else {
     paramMatrix <- .paramMatrix
   }
 
   traces <- array(dim=c(Nenkf+1,length(start)+1),
-                  dimnames=list(iteration=seq.int(.ndone,.ndone+Nenkf),
-                                variable=c("loglik",names(start))))
+    dimnames=list(iteration=seq.int(.ndone,.ndone+Nenkf),
+      variable=c("loglik",names(start))))
   traces[1L,] <- c(NA,start)
 
   pompLoad(object,verbose=verbose)
   on.exit(pompUnload(object,verbose=verbose))
 
   paramMatrix <- partrans(object,paramMatrix,dir="toEst",
-                          .gnsi=gnsi)
+    .gnsi=gnsi)
 
   ## iterate the filtering
   for (n in seq_len(Nenkf)) {
@@ -205,7 +203,7 @@ ienkf.internal <- function (object, Nenkf, rw.sd,
   }
 
   es@paramMatrix <- partrans(object,paramMatrix,dir="fromEst",
-                              .gnsi=gnsi)
+    .gnsi=gnsi)
 
   new(
     "ienkfd_spatPomp",
@@ -222,8 +220,8 @@ ienkf.internal <- function (object, Nenkf, rw.sd,
 ###################ienkf.filter()##################################
 ###################################################################
 ienkf.filter <- function (object, params, Np, enkfiter, rw.sd, cooling.fn,
-                 verbose, .indices = integer(0),
-                 .gnsi = TRUE) {
+  verbose, .indices = integer(0),
+  .gnsi = TRUE) {
 
   verbose <- as.logical(verbose)
   gnsi <- as.logical(.gnsi)
@@ -234,7 +232,7 @@ ienkf.filter <- function (object, params, Np, enkfiter, rw.sd, cooling.fn,
   if (do_ta && length(.indices)!=Np)
     pStop_(sQuote(".indices")," has improper length.")
 
-  times <- tt <- time(object,t0=TRUE)
+  times <- time(object,t0=TRUE)
   t <- time(object)
   ntimes <- length(times)-1
 
@@ -246,49 +244,45 @@ ienkf.filter <- function (object, params, Np, enkfiter, rw.sd, cooling.fn,
   for (nt in seq_len(ntimes)) {
     ## perturb parameters
     pmag <- cooling.fn(nt,enkfiter)$alpha*rw.sd[,nt]
-    params <- .Call('randwalk_perturbation_spatPomp',params,pmag,PACKAGE = 'spatPomp')
+    params <- .Call(randwalk_perturbation_spatPomp,params,pmag)
     tparams <- partrans(object,params,dir="fromEst",.gnsi=gnsi)
 
     ## get initial states
     if (nt == 1L) {
       X <- rinit(object,params=tparams)
       xnames <- rownames(X)
-      tpnames <- rownames(tparams)
       pnames <- rownames(params)
     }
 
-    ######################ENKF FROM HERE ON DOWN #################
+######################ENKF FROM HERE ON DOWN #################
 
     ## advance ensemble according to state process
     X <- rprocess(object,x0=X,t0=times[nt],times=times[nt+1],params=tparams,.gnsi=gnsi)
 
-    # data
-    yk <- y[,nt]
-
-    # ensemble of forecasts
+                                        # ensemble of forecasts
     Y <- tryCatch(
-      .Call('do_theta_to_e',
-            object=object,
-            X=X,
-            Np = as.integer(Np),
-            times=times[nt+1],
-            params=tparams,
-            gnsi=TRUE),
+      .Call(do_theta_to_e,
+        object=object,
+        X=X,
+        Np = as.integer(Np),
+        times=times[nt+1],
+        params=tparams,
+        gnsi=TRUE),
       error = function (e) {
         stop("ep",conditionMessage(e),call.=FALSE) # nocov
       }
     )
     Y <- Y[,,1]
 
-    # variance of artificial noise (i.e. R) computed using vmeasure
+                                        # variance of artificial noise (i.e. R) computed using vmeasure
     meas_var <- tryCatch(
-      .Call('do_theta_to_v',
-            object=object,
-            X=X,
-            Np = as.integer(Np[1]),
-            times=times[nt+1],
-            params=tparams,
-            gnsi=TRUE),
+      .Call(do_theta_to_v,
+        object=object,
+        X=X,
+        Np = as.integer(Np[1]),
+        times=times[nt+1],
+        params=tparams,
+        gnsi=TRUE),
       error = function (e) {
         stop("ep",conditionMessage(e),call.=FALSE) # nocov
       }
@@ -302,14 +296,14 @@ ienkf.filter <- function (object, params, Np, enkfiter, rw.sd, cooling.fn,
       }
     )
 
-    # expand the state space
+                                        # expand the state space
     XT <- rbind(X[,,1],params)
     pm <- rowMeans(XT) # prediction mean
 
-    # forecast mean
+                                        # forecast mean
     ym <- rowMeans(Y)
 
-    # center prediction and forecast ensembles
+                                        # center prediction and forecast ensembles
     XT <- XT-pm
     Y <- Y-ym
 
@@ -325,7 +319,7 @@ ienkf.filter <- function (object, params, Np, enkfiter, rw.sd, cooling.fn,
     params <- XT[pnames,,drop = FALSE]
     X <- XT[xnames,,drop = FALSE]
     loglik[nt] <- sum(dnorm(x=crossprod(svdS$u,resid),mean=0,sd=sqrt(svdS$d),log=TRUE))
-    # print(rowMeans(partrans(object,params,dir="fromEst",.gnsi=gnsi)))
+                                        # print(rowMeans(partrans(object,params,dir="fromEst",.gnsi=gnsi)))
 
     ## compute mean at last timestep
     if (nt == ntimes) {
@@ -333,20 +327,20 @@ ienkf.filter <- function (object, params, Np, enkfiter, rw.sd, cooling.fn,
     }
   }
   new("enkfd_spatPomp",
-      object,
-      Np=Np,
-      cond.logLik=loglik,
-      loglik=sum(loglik),
-      indices=.indices,
-      paramMatrix=params,
-      runit_measure = object@runit_measure,
-      dunit_measure = object@dunit_measure,
-      eunit_measure = object@eunit_measure,
-      vunit_measure = object@vunit_measure,
-      munit_measure = object@munit_measure,
-      unit_names=object@unit_names,
-      unit_statenames=object@unit_statenames,
-      unit_obsnames = object@unit_obsnames)
+    object,
+    Np=Np,
+    cond.logLik=loglik,
+    loglik=sum(loglik),
+    indices=.indices,
+    paramMatrix=params,
+    runit_measure = object@runit_measure,
+    dunit_measure = object@dunit_measure,
+    eunit_measure = object@eunit_measure,
+    vunit_measure = object@vunit_measure,
+    munit_measure = object@munit_measure,
+    unit_names=object@unit_names,
+    unit_statenames=object@unit_statenames,
+    unit_obsnames = object@unit_obsnames)
 }
 
 

--- a/R/igirf.R
+++ b/R/igirf.R
@@ -87,9 +87,9 @@ setMethod(
   "igirf",
   signature=signature(data="spatPomp"),
   definition=function (data,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.50,
-                        Ninter,lookahead=1,Nguide,kind=c('bootstrap', 'moment'),
-                        tol = 1e-300,
-                        ..., verbose = getOption("verbose", FALSE)) {
+    Ninter,lookahead=1,Nguide,kind=c('bootstrap', 'moment'),
+    tol = 1e-300,
+    ..., verbose = getOption("verbose", FALSE)) {
     if(missing(Ninter)) Ninter <- length(unit_names(data))
     kind = match.arg(kind)
     tryCatch(
@@ -109,8 +109,8 @@ setMethod(
   "igirf",
   signature=signature(data="igirfd_spatPomp"),
   function (data,Ngirf,Np,rw.sd,cooling.type, cooling.fraction.50, Ninter,
-            lookahead,Nguide,kind=c('bootstrap','moment'),tol, ...,
-            verbose = getOption("verbose", FALSE)) {
+    lookahead,Nguide,kind=c('bootstrap','moment'),tol, ...,
+    verbose = getOption("verbose", FALSE)) {
     if (missing(Ngirf)) Ngirf <- data@Ngirf
     if (missing(rw.sd)) rw.sd <- data@rw.sd
     if (missing(cooling.type)) cooling.type <- data@cooling.type
@@ -122,30 +122,30 @@ setMethod(
     if (missing(lookahead)) lookahead <- data@lookahead
 
     igirf(as(data,"spatPomp"), Ngirf=Ngirf, Np=Np,rw.sd = rw.sd, cooling.type = cooling.type,
-         cooling.fraction.50 = cooling.fraction.50, tol=tol, Ninter=Ninter, Nguide=Nguide,
-         kind=kind, lookahead=lookahead, ..., verbose=verbose)
+      cooling.fraction.50 = cooling.fraction.50, tol=tol, Ninter=Ninter, Nguide=Nguide,
+      kind=kind, lookahead=lookahead, ..., verbose=verbose)
   }
 )
 
 igirf.internal <- function (object,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.50,
-                            Ninter,lookahead,Nguide,kind,
-                            tol, ...,
-                            .ndone = 0L, .indices = integer(0),.paramMatrix = NULL,.gnsi = TRUE, verbose = FALSE) {
+  Ninter,lookahead,Nguide,kind,
+  tol, ...,
+  .ndone = 0L, .indices = integer(0),.paramMatrix = NULL,.gnsi = TRUE, verbose = FALSE) {
 
   verbose <- as.logical(verbose)
   p_object <- pomp(object,...,verbose=verbose)
   object <- new("spatPomp",p_object,
-                     unit_covarnames = object@unit_covarnames,
-                     shared_covarnames = object@shared_covarnames,
-                     runit_measure = object@runit_measure,
-                     dunit_measure = object@dunit_measure,
-                     eunit_measure = object@eunit_measure,
-                     munit_measure = object@munit_measure,
-                     vunit_measure = object@vunit_measure,
-                     unit_names=object@unit_names,
-                     unitname=object@unitname,
-                     unit_statenames=object@unit_statenames,
-                     unit_obsnames = object@unit_obsnames)
+    unit_covarnames = object@unit_covarnames,
+    shared_covarnames = object@shared_covarnames,
+    runit_measure = object@runit_measure,
+    dunit_measure = object@dunit_measure,
+    eunit_measure = object@eunit_measure,
+    munit_measure = object@munit_measure,
+    vunit_measure = object@vunit_measure,
+    unit_names=object@unit_names,
+    unitname=object@unitname,
+    unit_statenames=object@unit_statenames,
+    unit_obsnames = object@unit_obsnames)
   if (undefined(object@rprocess) || undefined(object@dmeasure))
     stop(paste(sQuote(c("rprocess","dmeasure")),collapse=", ")," are needed basic components.")
 
@@ -170,12 +170,12 @@ igirf.internal <- function (object,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.
       vapply(seq_len(ntimes),Np,numeric(1)),
       error = function (e) {
         stop("if ",sQuote("Np"),
-               " is a function, it must return a single positive integer.")
+          " is a function, it must return a single positive integer.")
       }
     )
   } else if (!is.numeric(Np)) {
     stop(sQuote("Np"),
-           " must be a number, a vector of numbers, or a function.")
+      " must be a number, a vector of numbers, or a function.")
   }
 
   if (length(Np) == 1) {
@@ -187,7 +187,7 @@ igirf.internal <- function (object,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.
     Np <- head(Np,ntimes)
   } else if (length(Np) < ntimes) {
     stop(sQuote("Np")," must have length 1 or ",
-           sQuote("length(time(object))"),".")
+      sQuote("length(time(object))"),".")
   }
 
   if (!all(is.finite(Np)) || any(Np <= 0))
@@ -198,15 +198,15 @@ igirf.internal <- function (object,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.
 
   if (missing(rw.sd))
     stop(sQuote("rw.sd")," must be specified!")
-  #rw.sd <- perturbn.kernel.sd(rw.sd,time=time(object),paramnames=names(start))
+  ##rw.sd <- perturbn.kernel.sd(rw.sd,time=time(object),paramnames=names(start))
   rw.sd <- perturbn.kernel.sd(rw.sd,
-                                     time=igirf_rw_sd_times(times=time(object),Ninter=Ninter),
-                                     paramnames=names(start))
+    time=igirf_rw_sd_times(times=time(object),Ninter=Ninter),
+    paramnames=names(start))
   if (missing(cooling.fraction.50))
     stop(sQuote("cooling.fraction.50")," is a required argument.")
   if (length(cooling.fraction.50) != 1 || !is.numeric(cooling.fraction.50) ||
-      !is.finite(cooling.fraction.50) || cooling.fraction.50 <= 0 ||
-      cooling.fraction.50 > 1)
+        !is.finite(cooling.fraction.50) || cooling.fraction.50 <= 0 ||
+          cooling.fraction.50 > 1)
     stop(sQuote("cooling.fraction.50")," must be in (0,1].")
   cooling.fraction.50 <- as.numeric(cooling.fraction.50)
 
@@ -218,36 +218,37 @@ igirf.internal <- function (object,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.
 
   if (is.null(.paramMatrix)) {
     paramMatrix <- array(data=start,dim=c(length(start),Np[1L]),
-                         dimnames=list(variable=names(start),rep=NULL))
+      dimnames=list(variable=names(start),rep=NULL))
   } else {
     paramMatrix <- .paramMatrix
   }
 
   traces <- array(dim=c(Ngirf+1,length(start)+1),
-                  dimnames=list(iteration=seq.int(.ndone,.ndone+Ngirf),
-                                variable=c('loglik',names(start))))
+    dimnames=list(iteration=seq.int(.ndone,.ndone+Ngirf),
+      variable=c('loglik',names(start))))
   traces[1L,] <- c(NA,start)
 
   pompLoad(object,verbose=verbose)
   on.exit(pompUnload(object,verbose=verbose))
 
   paramMatrix <- partrans(object,paramMatrix,dir="toEst",
-                          .gnsi=gnsi)
+    .gnsi=gnsi)
 
   ## iterate the filtering
   for (n in seq_len(Ngirf)) {
     if(kind == 'moment'){
       g <- igirf.momgirf(object=object,Ninter=Ninter,Nguide=Nguide,lookahead=lookahead,
-                      params=paramMatrix,
-                      Np=Np,girfiter=.ndone+n,cooling.fn=cooling.fn,rw.sd=rw.sd,tol=tol,
-                      verbose=verbose,.indices=.indices, .gnsi=gnsi)
+        params=paramMatrix,
+        Np=Np,girfiter=.ndone+n,cooling.fn=cooling.fn,rw.sd=rw.sd,tol=tol,
+        verbose=verbose,.indices=.indices, .gnsi=gnsi)
     }
     if(kind == 'bootstrap'){
-      g <- igirf.bootgirf(object=object,Ninter=Ninter,Nguide=Nguide,lookahead=lookahead,
-                      params=paramMatrix,
-                      Np=Np,girfiter=.ndone+n,cooling.fn=cooling.fn,rw.sd=rw.sd,tol=tol,
-                      verbose=verbose,.indices=.indices, .gnsi=gnsi)
-
+      g <- igirf.bootgirf(
+        object=object,Ninter=Ninter,Nguide=Nguide,lookahead=lookahead,
+        params=paramMatrix,
+        Np=Np,girfiter=.ndone+n,cooling.fn=cooling.fn,rw.sd=rw.sd,tol=tol,
+        verbose=verbose,.indices=.indices, .gnsi=gnsi
+      )
     }
     gnsi <- FALSE
 
@@ -263,7 +264,7 @@ igirf.internal <- function (object,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.
   }
 
   g@paramMatrix <- partrans(object,paramMatrix,dir="fromEst",
-                              .gnsi=gnsi)
+    .gnsi=gnsi)
 
   new(
     "igirfd_spatPomp",
@@ -277,8 +278,8 @@ igirf.internal <- function (object,Ngirf,Np,rw.sd,cooling.type,cooling.fraction.
 }
 
 igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
-                        Np, girfiter, rw.sd, cooling.fn, tol,
-                        ..., verbose, .indices = integer(0), .gnsi = TRUE) {
+  Np, girfiter, rw.sd, cooling.fn, tol,
+  ..., verbose, .indices = integer(0), .gnsi = TRUE) {
 
   tol <- as.numeric(tol)
   gnsi <- as.logical(.gnsi)
@@ -298,42 +299,47 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
   ntimes <- length(times)-1
   nunits <- length(unit_names(object))
 
-  loglik <- rep(NA,ntimes)
   cond.loglik <- array(0, dim = c(ntimes, Ninter))
 
   znames <- object@accumvars
 
-  # Initialize filter guide function
+                                        # Initialize filter guide function
   log_filter_guide_fun <- array(0, dim = Np[1])
   for (nt in 0:(ntimes-1)) {
     pmag <- cooling.fn(nt,girfiter)$alpha*rw.sd[,nt]
-    params <- .Call("randwalk_perturbation_spatPomp",params,pmag,PACKAGE="spatPomp")
+    params <- .Call(randwalk_perturbation_spatPomp,params,pmag)
     tparams <- partrans(object,params,dir="fromEst",.gnsi=gnsi)
     if (nt == 0) {
       x <- rinit(object,params=tparams)
       statenames <- rownames(x)
-      paramnames <- rownames(tparams)
-      nvars <- nrow(x)
     }
-    # Intermediate times. using seq to get S+1 points between t_n and t_{n+1} inclusive
+    ## Intermediate times. using seq to get S+1 points between t_n and t_{n+1} inclusive
     tt <- seq(from=times[nt+1],to=times[nt+2],length.out=Ninter+1)
-    lookahead_steps = min(lookahead, ntimes-nt)
-    # Four-dimensional array: nvars by nguide by ntimes by nreps
-    Xg = array(0, dim=c(length(statenames), Nguide, lookahead_steps, Np[1]), dimnames = list(nvars = statenames, ng = NULL, lookahead = 1:lookahead_steps, nreps = NULL))
-    # For each particle get K guide particles, and fill in sample variance over K for each (lookahead value - unit - particle) combination
+    lookahead_steps <- min(lookahead, ntimes-nt)
+    ## Four-dimensional array: nvars by nguide by ntimes by nreps
+    Xg <- array(0,
+      dim=c(length(statenames), Nguide, lookahead_steps, Np[1]),
+      dimnames = list(
+        nvars = statenames,
+        ng = NULL,
+        lookahead = seq_len(lookahead_steps),
+        nreps = NULL
+      )
+    )
+                                        # For each particle get K guide particles, and fill in sample variance over K for each (lookahead value - unit - particle) combination
     fcst_samp_var <- array(0, dim = c(length(unit_names(object)), lookahead_steps, Np[1]))
     x_with_guides <- x[,rep(1:Np[1], rep(Nguide, Np[1]))]
     tp_with_guides <- tparams[,rep(1:Np[1], rep(Nguide, Np[1]))]
     Xg <- rprocess(object, x0=x_with_guides, t0=times[nt+1], times=times[(nt+2):(nt+1+lookahead_steps)],
-                   params=tp_with_guides,.gnsi=gnsi)
+      params=tp_with_guides,.gnsi=gnsi)
     xx <- tryCatch(
-      .Call('do_fcst_samp_var',
-            object=object,
-            X=Xg,
-            Np = as.integer(Np[1]),
-            times=times[(nt+2):(nt+1+lookahead_steps)],
-            params=tp_with_guides,
-            gnsi=TRUE),
+      .Call(do_fcst_samp_var,
+        object=object,
+        X=Xg,
+        Np = as.integer(Np[1]),
+        times=times[(nt+2):(nt+1+lookahead_steps)],
+        params=tp_with_guides,
+        gnsi=TRUE),
       error = function (e) {
         stop(ep,conditionMessage(e),call.=FALSE) # nocov
       }
@@ -343,9 +349,9 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
 
     for (s in 1:Ninter){
       tparams <- partrans(object,params,dir="fromEst",.gnsi=gnsi)
-      # Get prediction simulations: nvars by nreps by 1 array
+                                        # Get prediction simulations: nvars by nreps by 1 array
       X <- rprocess(object,x0=x, t0 = tt[s], times= tt[s+1],
-                    params=tparams,.gnsi=gnsi)
+        params=tparams,.gnsi=gnsi)
       if(s>1 && length(znames)>0){
         x.znames <- x[znames,]; dim(x.znames) <- c(dim(x.znames),1)
         X[znames,,] <- X[znames,,,drop=FALSE] + x.znames
@@ -353,11 +359,11 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
       X.start <- X[,,1]
       if(tt[s+1] < times[nt + 1 + lookahead_steps]){
         skel <- pomp::flow(object,
-                       x0=X.start,
-                       t0=tt[s+1],
-                       params=tparams,
-                       times = times[(nt + 1 + 1):(nt + 1 + lookahead_steps)],
-                       method = 'adams')
+          x0=X.start,
+          t0=tt[s+1],
+          params=tparams,
+          times = times[(nt + 1 + 1):(nt + 1 + lookahead_steps)],
+          method = 'adams')
         skel.start <- skel[,,1]
         X.start.znames <- X.start[znames,]
         skel.start.znames <- skel.start[znames,]
@@ -367,13 +373,13 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
         skel <- X
       }
       meas_var_skel <- tryCatch(
-        .Call('do_theta_to_v',
-              object=object,
-              X=skel,
-              Np = as.integer(Np[1]),
-              times=times[(nt+2):(nt+1+lookahead_steps)],
-              params=tparams,
-              gnsi=TRUE),
+        .Call(do_theta_to_v,
+          object=object,
+          X=skel,
+          Np = as.integer(Np[1]),
+          times=times[(nt+2):(nt+1+lookahead_steps)],
+          params=tparams,
+          gnsi=TRUE),
         error = function (e) {
           stop(ep,conditionMessage(e),call.=FALSE) # nocov
         }
@@ -385,14 +391,14 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
       array.tparams <- array(NA, dim = c(dim(tparams)[1], length(unit_names(object)), Np[1], lookahead_steps), dimnames = list(tparams = rownames(tparams)))
       for(i in 1:length(unit_names(object))) array.tparams[,i,,1:lookahead_steps] <- tparams
       mmp <- tryCatch(
-        .Call('do_v_to_theta',
-              object=object,
-              X=skel,
-              vc=inflated_var,
-              Np = as.integer(Np[1]),
-              times=times[(nt+2):(nt+1+lookahead_steps)],
-              params=array.tparams,
-              gnsi=TRUE),
+        .Call(do_v_to_theta,
+          object=object,
+          X=skel,
+          vc=inflated_var,
+          Np = as.integer(Np[1]),
+          times=times[(nt+2):(nt+1+lookahead_steps)],
+          params=array.tparams,
+          gnsi=TRUE),
         error = function (e) {
           stop(ep,conditionMessage(e),call.=FALSE) # nocov
         }
@@ -400,29 +406,29 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
       mom_match_param <- mmp
       dim(mom_match_param) <- c(dim(tparams)[1], length(unit_names(object)), lookahead_steps, Np[1])
       dimnames(mom_match_param) <- list(tparam = rownames(tparams))
-      log_guide_fun = vector(mode = "numeric", length = Np[1]) + 1
+      log_guide_fun <- vector(mode = "numeric", length = Np[1]) + 1
 
       for(l in 1:lookahead_steps){
-        if(nt+1+l-lookahead <= 0) discount_denom_init = object@t0
-        else discount_denom_init = times[nt+1+l - lookahead]
-        discount_factor = 1 - (times[nt+1+l] - tt[s+1])/(times[nt+1+l] - discount_denom_init)/ifelse(lookahead==1,2,1) ## to ensure that the discount factor does not become too small for L=1 and small s (which can lead to very uninformative guide function), increase the discount factor to at least 1/2 when L=1.
+        if(nt+1+l-lookahead <= 0) discount_denom_init <- object@t0
+        else discount_denom_init <- times[nt+1+l - lookahead]
+        discount_factor <- 1 - (times[nt+1+l] - tt[s+1])/(times[nt+1+l] - discount_denom_init)/ifelse(lookahead==1,2,1) ## to ensure that the discount factor does not become too small for L=1 and small s (which can lead to very uninformative guide function), increase the discount factor to at least 1/2 when L=1.
         log_dmeas_weights <- tryCatch(
-          (vec_dmeasure(
-            object,
-            y=object@data[,nt+l,drop=FALSE],
-            x=skel[,,l,drop = FALSE],
-            times=times[nt+1+l],
-            params=mom_match_param[,,l,],
-            log=TRUE,
-            .gnsi=gnsi
-          )),
-          error = function (e) {
-            stop(ep,"error in calculation of log_dmeas_weights: ",
-                 conditionMessage(e),call.=FALSE)
-          }
+        (vec_dmeasure(
+          object,
+          y=object@data[,nt+l,drop=FALSE],
+          x=skel[,,l,drop = FALSE],
+          times=times[nt+1+l],
+          params=mom_match_param[,,l,],
+          log=TRUE,
+          .gnsi=gnsi
+        )),
+        error = function (e) {
+          stop(ep,"error in calculation of log_dmeas_weights: ",
+            conditionMessage(e),call.=FALSE)
+        }
         )
         if(any(is.na(log_dmeas_weights))){
-          # find particle with the NA
+                                        # find particle with the NA
           na_ix <- which(is.na(log_dmeas_weights[,,1]))[1]
           na_ix_col <- (na_ix %/% nunits) + (na_ix %% nunits > 0)
           illegal_dunit_measure_error(
@@ -434,7 +440,7 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
           )
         }
         log_resamp_weights <- apply(log_dmeas_weights[,,1,drop=FALSE], 2, function(x) sum(x))*discount_factor
-        log_guide_fun = log_guide_fun + log_resamp_weights
+        log_guide_fun <- log_guide_fun + log_resamp_weights
       }
       log_s_not_1_weights <- log_guide_fun - log_filter_guide_fun
       if (!(s==1 & nt!=0)){
@@ -456,7 +462,7 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
           ),
           error = function (e) {
             stop(ep,"error in calculation of log_meas_weights: ",
-                 conditionMessage(e),call.=FALSE)
+              conditionMessage(e),call.=FALSE)
           }
         )
         gnsi <- FALSE
@@ -467,7 +473,7 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
           coef(object,transform=TRUE) <- apply(params,1L,weighted.mean,w=exp(log_weights))
         } else {
           warning("igirf: ","filtering failure at last filter iteration; using ",
-                "unweighted mean for point estimate.")
+            "unweighted mean for point estimate.")
           coef(object,transform=TRUE) <- apply(params,1L,mean)
         }
       }
@@ -476,16 +482,16 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
         log_weights <- log_weights - max_log_weights
         weights <- exp(log_weights)
         xx <- tryCatch(
-          .Call('girf_computations',
-                x=X,
-                params=params,
-                Np=Np[nt+1],
-                trackancestry=FALSE,
-                doparRS=TRUE,
-                weights=weights,
-                lgps=log_guide_fun,
-                fsv=fcst_samp_var,
-                tol=tol
+          .Call(girf_computations,
+            x=X,
+            params=params,
+            Np=Np[nt+1],
+            trackancestry=FALSE,
+            doparRS=TRUE,
+            weights=weights,
+            lgps=log_guide_fun,
+            fsv=fcst_samp_var,
+            tol=tol
           ),
           error = function (e) {
             stop(ep,conditionMessage(e),call.=FALSE) # nocov
@@ -519,8 +525,8 @@ igirf.momgirf <- function (object, params, Ninter, lookahead, Nguide,
 }
 
 igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
-                            Np, girfiter, rw.sd, cooling.fn, tol,
-                            ..., verbose, .indices = integer(0), .gnsi = TRUE) {
+  Np, girfiter, rw.sd, cooling.fn, tol,
+  ..., verbose, .indices = integer(0), .gnsi = TRUE) {
 
   tol <- as.numeric(tol)
   gnsi <- as.logical(.gnsi)
@@ -540,7 +546,6 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
   ntimes <- length(times)-1
   nunits <- length(unit_names(object))
 
-  loglik <- rep(NA,ntimes)
   cond.loglik <- array(0, dim = c(ntimes, Ninter))
 
   znames <- object@accumvars
@@ -548,36 +553,42 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
   log_filter_guide_fun <- array(0, dim = Np[1])
   for (nt in 0:(ntimes-1)) {
     pmag <- cooling.fn(nt,girfiter)$alpha*rw.sd[,nt]
-    params <- .Call("randwalk_perturbation_spatPomp",params,pmag,PACKAGE="spatPomp")
+    params <- .Call(randwalk_perturbation_spatPomp,params,pmag)
     tparams <- partrans(object,params,dir="fromEst",.gnsi=gnsi)
     if (nt == 0) {
       x <- rinit(object,params=tparams)
       statenames <- rownames(x)
-      paramnames <- rownames(tparams)
-      nvars <- nrow(x)
     }
     tt <- seq(from=times[nt+1],to=times[nt+2],length.out=Ninter+1)
-    lookahead_steps = min(lookahead, ntimes-nt)
-    # Four-dimensional array: nvars by nguide by ntimes by nreps
-    Xg = array(0, dim=c(length(statenames), Nguide, lookahead_steps, Np[1]), dimnames = list(nvars = statenames, ng = NULL, lookahead = 1:lookahead_steps, nreps = NULL))
-    x_with_guides <- x[,rep(1:Np[1], each = Nguide)]
-    tp_with_guides <- tparams[,rep(1:Np[1], each = Nguide)]
-    guidesim_index <- 1:Np[1] # the index for guide simulations (to be updated each time resampling occurs)
+    lookahead_steps <- min(lookahead, ntimes-nt)
+    ## Four-dimensional array: nvars by nguide by ntimes by nreps
+    Xg <- array(0,
+      dim=c(length(statenames), Nguide, lookahead_steps, Np[1]),
+      dimnames = list(
+        nvars = statenames,
+        ng = NULL,
+        lookahead = seq_len(lookahead_steps),
+        nreps = NULL
+      )
+    )
+    guidesim_index <- seq_len(Np[1]) ## the index for guide simulations (to be updated each time resampling occurs)
+    x_with_guides <- x[,rep(guidesim_index, each = Nguide)]
+    tp_with_guides <- tparams[,rep(guidesim_index, each = Nguide)]
     Xg <- rprocess(object, x0=x_with_guides, t0=times[nt+1], times=times[(nt+2):(nt+1+lookahead_steps)],
-                   params=tp_with_guides,.gnsi=gnsi)
+      params=tp_with_guides,.gnsi=gnsi)
     Xskel <- pomp::flow(object,
-                   x0=x,
-                   t0=times[nt+1],
-                   params=tparams,
-                   times = times[(nt+2):(nt+1+lookahead_steps)],
-                   method = 'adams')
+      x0=x,
+      t0=times[nt+1],
+      params=tparams,
+      times = times[(nt+2):(nt+1+lookahead_steps)],
+      method = 'adams')
     resids <- Xg - Xskel[,rep(1:Np[1], each=Nguide),,drop=FALSE] # residuals
     rm(Xg, Xskel, x_with_guides)
     for (s in 1:Ninter){
       tparams <- partrans(object,params,dir="fromEst",.gnsi=gnsi)
       tp_with_guides <- tparams[,rep(1:Np[1], rep(Nguide, Np[1]))]
       X <- rprocess(object,x0=x, t0 = tt[s], times= tt[s+1],
-                    params=tparams,.gnsi=gnsi)
+        params=tparams,.gnsi=gnsi)
       if(s>1 && length(znames)>0){
         x.znames <- x[znames,]; dim(x.znames) <- c(dim(x.znames),1)
         X[znames,,] <- X[znames,,,drop=FALSE] + x.znames
@@ -585,11 +596,11 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
       X.start <- X[,,1]
       if(tt[s+1] < times[nt + 1 + lookahead_steps]){
         skel <- pomp::flow(object,
-                   x0=X.start,
-                   t0=tt[s+1],
-                   params=tparams,
-                   times = times[(nt + 1 + 1):(nt + 1 + lookahead_steps)],
-                   method = 'adams')
+          x0=X.start,
+          t0=tt[s+1],
+          params=tparams,
+          times = times[(nt + 1 + 1):(nt + 1 + lookahead_steps)],
+          method = 'adams')
         if(length(znames) > 0){
           skel.start <- skel[,,1]
           X.start.znames <- X.start[znames,]
@@ -600,36 +611,36 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
       } else {
         skel <- X
       }
-      log_guide_fun = vector(mode = "numeric", length = Np[1]) + 1
+      log_guide_fun <- vector(mode = "numeric", length = Np[1]) + 1
 
       for(l in 1:lookahead_steps){
-        if(nt+1+l-lookahead <= 0) discount_denom_init = object@t0
-        else discount_denom_init = times[nt+1+l - lookahead]
-        discount_factor = 1 - (times[nt+1+l] - tt[s+1])/(times[nt+1+l] - discount_denom_init)/ifelse(lookahead==1,2,1) ## to ensure that the discount factor does not become too small for L=1 and small s (which can lead to very uninformative guide function), increase the discount factor to at least 1/2 when L=1.
+        if(nt+1+l-lookahead <= 0) discount_denom_init <- object@t0
+        else discount_denom_init <- times[nt+1+l - lookahead]
+        discount_factor <- 1 - (times[nt+1+l] - tt[s+1])/(times[nt+1+l] - discount_denom_init)/ifelse(lookahead==1,2,1) ## to ensure that the discount factor does not become too small for L=1 and small s (which can lead to very uninformative guide function), increase the discount factor to at least 1/2 when L=1.
 
-        # construct pseudo-simulations by adding simulated noise terms (residuals) to the skeletons
+                                        # construct pseudo-simulations by adding simulated noise terms (residuals) to the skeletons
         pseudosims <- skel[,rep(1:Np[1], each=Nguide),l,drop=FALSE] +
           resids[,rep(guidesim_index-1, each=Nguide)*Nguide+rep(1:Nguide, Np[1]),l,drop=FALSE] -
           resids[,rep(guidesim_index-1, each=Nguide)*Nguide+rep(1:Nguide, Np[1]),1,drop=FALSE] +
           resids[,rep(guidesim_index-1, each=Nguide)*Nguide+rep(1:Nguide, Np[1]),1,drop=FALSE] * sqrt((times[nt+2]-tt[s+1])/(times[nt+2]-times[nt+1]))
         rm(skel)
         log_dmeas_weights <- tryCatch(
-          (vec_dmeasure(
-            object,
-            y=object@data[,nt+l,drop=FALSE],
-            x=pseudosims,
-            times=times[nt+1+l],
-            params=tp_with_guides,
-            log=TRUE,
-            .gnsi=gnsi
-          )),
-          error = function (e) {
-            stop(ep,"error in calculation of log_dmeas_weights: ",
-                 conditionMessage(e),call.=FALSE)
-          }
+        (vec_dmeasure(
+          object,
+          y=object@data[,nt+l,drop=FALSE],
+          x=pseudosims,
+          times=times[nt+1+l],
+          params=tp_with_guides,
+          log=TRUE,
+          .gnsi=gnsi
+        )),
+        error = function (e) {
+          stop(ep,"error in calculation of log_dmeas_weights: ",
+            conditionMessage(e),call.=FALSE)
+        }
         )
         if(any(is.na(log_dmeas_weights))){
-          # find particle with the NA
+                                        # find particle with the NA
           na_ix <- which(is.na(log_dmeas_weights[,,1]))[1]
           na_ix_col <- (na_ix %/% nunits) + (na_ix %% nunits > 0)
           illegal_dunit_measure_error(
@@ -665,7 +676,7 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
           ),
           error = function (e) {
             stop(ep,"error in calculation of log_meas_weights: ",
-                 conditionMessage(e),call.=FALSE)
+              conditionMessage(e),call.=FALSE)
           }
         )
         gnsi <- FALSE
@@ -676,7 +687,7 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
           coef(object,transform=TRUE) <- apply(params,1L,weighted.mean,w=exp(log_weights))
         } else {
           pWarn("ibootgirf","filtering failure at last filter iteration; using ",
-                       "unweighted mean for point estimate.")
+            "unweighted mean for point estimate.")
           coef(object,transform=TRUE) <- apply(params,1L,mean)
         }
       }
@@ -685,16 +696,16 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
         log_weights <- log_weights - max_log_weights
         weights <- exp(log_weights)
         xx <- tryCatch(
-          .Call('girf_computations',
-                x=X,
-                params=params,
-                Np=Np[nt+1],
-                trackancestry=TRUE,
-                doparRS=TRUE,
-                weights=weights,
-                lgps=log_guide_fun,
-                fsv=array(0,dim=c(length(unit_names(object)), lookahead_steps, Np[1])), # bootgirf2 doesn't use fsv, set to an arbitrary val.
-                tol=tol
+          .Call(girf_computations,
+            x=X,
+            params=params,
+            Np=Np[nt+1],
+            trackancestry=TRUE,
+            doparRS=TRUE,
+            weights=weights,
+            lgps=log_guide_fun,
+            fsv=array(0,dim=c(length(unit_names(object)), lookahead_steps, Np[1])), # bootgirf2 doesn't use fsv, set to an arbitrary val.
+            tol=tol
           ),
           error = function (e) {
             stop(ep,conditionMessage(e),call.=FALSE) # nocov
@@ -705,7 +716,6 @@ igirf.bootgirf <- function (object, params, Ninter, lookahead, Nguide,
         x <- xx$states
         log_filter_guide_fun <- xx$logfilterguides
         params <- xx$params
-        fcst_samp_var <- xx$newfsv
       }
       else{
         cond.loglik[nt+1, s] <- log(tol)
@@ -741,7 +751,7 @@ illegal_dunit_measure_error <- function(time, lik, datvals, states, params){
 igirf_rw_sd_times <- function(times, Ninter){
   rw_sd_times <- c()
   for(i in seq(length(times)-1)) rw_sd_times <- c(
-    rw_sd_times, seq(from=times[i],to=times[i+1],length.out=Ninter+1))
+                                   rw_sd_times, seq(from=times[i],to=times[i+1],length.out=Ninter+1))
   return(rw_sd_times)
 }
 

--- a/R/lorenz.R
+++ b/R/lorenz.R
@@ -21,10 +21,10 @@
 #' spy(l)
 #' @export
 lorenz <- function(U=5,
-                   N=100,
-                   delta_t=0.01,
-                   delta_obs=0.5,
-                   regular_params=c(F=8, sigma=1, tau=1)){
+  N=100,
+  delta_t=0.01,
+  delta_obs=0.5,
+  regular_params=c(F=8, sigma=1, tau=1)){
 
   if(U<3.5)stop("Please use U >= 4")
   lorenz_globals <- Csnippet(paste0("#define U ", U, "\n"))
@@ -32,7 +32,6 @@ lorenz <- function(U=5,
   lorenz_obs_names <- paste0("U",1:U)
   lorenz_data <- data.frame(time=rep((1:N)*delta_obs,U),
     unit=rep(lorenz_obs_names,each=N),Y=rep(NA,U*N),stringsAsFactors=F)
-  lorenz_state_names <- paste0("X",1:U)
 
   ## initial value parameters
   lorenz_IVPnames <- paste0(lorenz_unit_statenames,1:U,"_0")
@@ -130,23 +129,23 @@ lorenz <- function(U=5,
   ")
 
   lorenz <- spatPomp(lorenz_data,
-                 times="time",
-                 t0=0,
-                 units="unit",
-                 unit_statenames = lorenz_unit_statenames,
-                 rprocess=euler(lorenz_rprocess,delta.t=delta_t),
-                 skeleton=vectorfield(lorenz_skel),
-                 paramnames=lorenz_paramnames,
-                 globals=lorenz_globals,
-                 rmeasure=lorenz_rmeasure,
-                 dmeasure=lorenz_dmeasure,
-                 eunit_measure=lorenz_eunit_measure,
-                 munit_measure=lorenz_munit_measure,
-                 vunit_measure=lorenz_vunit_measure,
-                 dunit_measure=lorenz_dunit_measure,
-                 runit_measure=lorenz_runit_measure,
-                 partrans = parameter_trans(log = c("F", "sigma", "tau")),
-                 rinit=lorenz_rinit)
+    times="time",
+    t0=0,
+    units="unit",
+    unit_statenames = lorenz_unit_statenames,
+    rprocess=euler(lorenz_rprocess,delta.t=delta_t),
+    skeleton=vectorfield(lorenz_skel),
+    paramnames=lorenz_paramnames,
+    globals=lorenz_globals,
+    rmeasure=lorenz_rmeasure,
+    dmeasure=lorenz_dmeasure,
+    eunit_measure=lorenz_eunit_measure,
+    munit_measure=lorenz_munit_measure,
+    vunit_measure=lorenz_vunit_measure,
+    dunit_measure=lorenz_dunit_measure,
+    runit_measure=lorenz_runit_measure,
+    partrans = parameter_trans(log = c("F", "sigma", "tau")),
+    rinit=lorenz_rinit)
 
   ## We need a parameter vector. For now, we initialize the process at zero,
   ## with a small perturbation for state U.

--- a/R/measles.R
+++ b/R/measles.R
@@ -66,9 +66,7 @@ measles <- function(U=6,dt=2/365,
   u <- split(measles_covar$births,measles_covar$city)
   v <- sapply(u,function(x){c(rep(NA,birth_lag),x[1:(length(x)-birth_lag)])})
   measles_covar$lag_birthrate <- as.vector(v[,cities])*26
-  measles_covar$births<- NULL
-  measles_covarnames <- paste0(rep(c("pop","lag_birthrate"),each=U),1:U)
-  measles_unit_covarnames <- c("pop","lag_birthrate")
+  measles_covar$births <- NULL
 
   # Distance between two points on a sphere radius R
   # Adapted from geosphere package, which has been cited in the package

--- a/R/munit_measure.R
+++ b/R/munit_measure.R
@@ -47,7 +47,7 @@ setMethod(
     storage.mode(params) <- "double"
     storage.mode(vc) <- "double"
     storage.mode(unit) <- "integer"
-    out <- .Call('do_v_to_theta',
+    out <- .Call(do_v_to_theta,
           object=object,
           X=x,
           vc=vc,

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -39,20 +39,19 @@ setMethod(
   "simulate",
   signature=signature(object="spatPomp"),
   definition=function(object, nsim = 1, seed = NULL,
-                      format = c("spatPomps", "data.frame"),
-                      include.data = FALSE,...) {
+    format = c("spatPomps", "data.frame"),
+    include.data = FALSE,...) {
     format <- match.arg(format)
     if(format == 'spatPomps') sims <- pomp::simulate(pomp(object), format = 'pomps', nsim = nsim, include.data = include.data, seed = seed, ...)
     if(format == 'data.frame') sims <- pomp::simulate(pomp(object), format = format, nsim = nsim, include.data = include.data, seed = seed, ...)
     if(format=="data.frame"){
-      unitname <- object@unitname
       unit_stateobs <- c(object@unit_obsnames, object@unit_statenames)
       unit_stateobs_pat <- paste0(paste("^",unit_stateobs,sep=""), collapse = "|")
       get_unit_index_from_statename <- function(statename){
         stringr::str_split(statename,unit_stateobs_pat)[[1]][2]
       }
       get_unit_index_from_statename_v <- Vectorize(get_unit_index_from_statename)
-      # convert to long format and output
+                                        # convert to long format and output
       to_gather <- colnames(sims)[3:length(colnames(sims))][!c(colnames(sims)[3:length(colnames(sims))]%in%object@shared_covarnames)] # all columns except time and .id
       to_select <- c(colnames(sims)[1:2], "unit", "stateobs", "val")
       to_arrange <- c(colnames(sims)[1], "unit", "stateobs")
@@ -71,40 +70,40 @@ setMethod(
       return(gathered)
     }
     if(format=="spatPomps"){
-      # add back spatPomp components into a list of spatPomps
+                                        # add back spatPomp components into a list of spatPomps
       if(nsim > 1){
         sp.list <- vector(mode="list", length = nsim)
         for(i in 1:length(sims)){
           sp <- new("spatPomp",sims[[i]],
-                    unit_covarnames = object@unit_covarnames,
-                    shared_covarnames = object@shared_covarnames,
-                    runit_measure = object@runit_measure,
-                    dunit_measure = object@dunit_measure,
-                    eunit_measure = object@eunit_measure,
-                    munit_measure = object@munit_measure,
-                    vunit_measure = object@vunit_measure,
-                    unit_names=object@unit_names,
-                    unitname=object@unitname,
-                    unit_statenames=object@unit_statenames,
-                    unit_accumvars = object@unit_accumvars,
-                    unit_obsnames = object@unit_obsnames)
+            unit_covarnames = object@unit_covarnames,
+            shared_covarnames = object@shared_covarnames,
+            runit_measure = object@runit_measure,
+            dunit_measure = object@dunit_measure,
+            eunit_measure = object@eunit_measure,
+            munit_measure = object@munit_measure,
+            vunit_measure = object@vunit_measure,
+            unit_names=object@unit_names,
+            unitname=object@unitname,
+            unit_statenames=object@unit_statenames,
+            unit_accumvars = object@unit_accumvars,
+            unit_obsnames = object@unit_obsnames)
           sp.list[[i]] <- sp
         }
         return(sp.list)
       } else{
         sp <- new("spatPomp",sims,
-                  unit_covarnames = object@unit_covarnames,
-                  shared_covarnames = object@shared_covarnames,
-                  dunit_measure = object@dunit_measure,
-                  runit_measure = object@runit_measure,
-                  eunit_measure = object@eunit_measure,
-                  munit_measure = object@munit_measure,
-                  vunit_measure = object@vunit_measure,
-                  unit_names=object@unit_names,
-                  unitname=object@unitname,
-                  unit_statenames=object@unit_statenames,
-                  unit_accumvars = object@unit_accumvars,
-                  unit_obsnames = object@unit_obsnames)
+          unit_covarnames = object@unit_covarnames,
+          shared_covarnames = object@shared_covarnames,
+          dunit_measure = object@dunit_measure,
+          runit_measure = object@runit_measure,
+          eunit_measure = object@eunit_measure,
+          munit_measure = object@munit_measure,
+          vunit_measure = object@vunit_measure,
+          unit_names=object@unit_names,
+          unitname=object@unitname,
+          unit_statenames=object@unit_statenames,
+          unit_accumvars = object@unit_accumvars,
+          unit_obsnames = object@unit_obsnames)
         return(sp)
       }
     }

--- a/R/spatPomp.R
+++ b/R/spatPomp.R
@@ -84,11 +84,11 @@ setGeneric(
 ##' @rdname spatPomp
 ##' @export
 spatPomp <- function (data, units, times, covar, t0, ...,
-                      eunit_measure, munit_measure, vunit_measure, dunit_measure, runit_measure,
-                      rprocess, rmeasure, dprocess, dmeasure, skeleton, rinit, rprior, dprior,
-                      unit_statenames, unit_accumvars, shared_covarnames, globals, paramnames, params,
-                      cdir,cfile, shlib.args, PACKAGE,
-                      partrans, compile=TRUE, verbose = getOption("verbose",FALSE)) {
+  eunit_measure, munit_measure, vunit_measure, dunit_measure, runit_measure,
+  rprocess, rmeasure, dprocess, dmeasure, skeleton, rinit, rprior, dprior,
+  unit_statenames, unit_accumvars, shared_covarnames, globals, paramnames, params,
+  cdir,cfile, shlib.args, PACKAGE,
+  partrans, compile=TRUE, verbose = getOption("verbose",FALSE)) {
 
   ep <- paste0("in ",sQuote("spatPomp"),": ")
 
@@ -97,18 +97,18 @@ spatPomp <- function (data, units, times, covar, t0, ...,
 
   if (!inherits(data,what=c("data.frame","spatPomp")))
     pStop("spatPomp",sQuote("data")," must be a data frame or an object of ",
-          "class ",sQuote("spatPomp"),".")
+      "class ",sQuote("spatPomp"),".")
 
   ## return as quickly as possible if no work is to be done
   if (is(data,"spatPomp") && missing(times) && missing(t0) &&
-      missing(dunit_measure) && missing(eunit_measure) &&
-      missing(vunit_measure) && missing(munit_measure) &&
-      missing(runit_measure) &&
-      missing(rinit) && missing(rprocess) && missing(dprocess) &&
-      missing(rmeasure) && missing(dmeasure) && missing(skeleton) &&
-      missing(rprior) && missing(dprior) && missing(partrans) &&
-      missing(covar) && missing(params) && missing(unit_accumvars) &&
-      length(list(...)) == 0)
+        missing(dunit_measure) && missing(eunit_measure) &&
+        missing(vunit_measure) && missing(munit_measure) &&
+        missing(runit_measure) &&
+        missing(rinit) && missing(rprocess) && missing(dprocess) &&
+        missing(rmeasure) && missing(dmeasure) && missing(skeleton) &&
+        missing(rprior) && missing(dprior) && missing(partrans) &&
+        missing(covar) && missing(params) && missing(unit_accumvars) &&
+        length(list(...)) == 0)
     return(as(data,"spatPomp"))
 
   if (missing(times)) times <- NULL
@@ -131,14 +131,15 @@ spatPomp <- function (data, units, times, covar, t0, ...,
     error = function (e) stop(conditionMessage(e))
   )
 }
-# Takes care of case where times or units has been set to NULL
+
+## Takes care of case where times or units has been set to NULL
 setMethod(
   "construct_spatPomp",
   signature=signature(data="ANY", times="ANY", units="ANY"),
   definition = function (data, times, t0, ...) {
     stop(sQuote("times")," should be a single name identifying the column of data that represents",
-           " the observation times. ", sQuote("units"), " should be likewise for column that represents",
-           " the observation units.")
+      " the observation times. ", sQuote("units"), " should be likewise for column that represents",
+      " the observation units.")
   }
 )
 
@@ -146,11 +147,11 @@ setMethod(
   "construct_spatPomp",
   signature=signature(data="data.frame", times="character", units="character"),
   definition = function (data, times, units, t0, ...,
-                         rinit, rprocess, dprocess, rmeasure, dmeasure, skeleton, rprior, dprior,
-                         partrans, params, covar, unit_accumvars, dunit_measure, eunit_measure,
-                         vunit_measure, munit_measure, runit_measure, unit_statenames,
-                         paramnames, shared_covarnames, PACKAGE, globals,
-                         cdir, cfile, shlib.args, compile, verbose) {
+    rinit, rprocess, dprocess, rmeasure, dmeasure, skeleton, rprior, dprior,
+    partrans, params, covar, unit_accumvars, dunit_measure, eunit_measure,
+    vunit_measure, munit_measure, runit_measure, unit_statenames,
+    paramnames, shared_covarnames, PACKAGE, globals,
+    cdir, cfile, shlib.args, compile, verbose) {
 
     if (anyDuplicated(names(data)))
       stop("names of data variables must be unique.")
@@ -162,27 +163,27 @@ setMethod(
 
     if (length(times) != 1 || tpos == 0L)
       stop(sQuote("times")," does not identify a single column of ",
-             sQuote("data")," by name.")
+        sQuote("data")," by name.")
     if (length(units) != 1 || upos == 0L)
       stop(sQuote("units")," does not identify a single column of ",
-             sQuote("data")," by name.")
+        sQuote("data")," by name.")
 
     timename <- times
     unitname <- units
 
-    # units slot contains unique units. unit_names is an "ordering" of units
+    ## units slot contains unique units. unit_names is an "ordering" of units
     unit_names <- unique(data[[upos]]); U <- length(unit_names)
 
-    # get observation types
+    ## get observation types
     unit_obsnames <- names(data)[-c(upos,tpos)]
     if(missing(unit_statenames)) unit_statenames <- as.character(NULL)
-    if (!missing(unit_accumvars)) pomp_accumvars <- paste0(rep(unit_accumvars,each=U),1:U)
+    if (!missing(unit_accumvars)) pomp_accumvars <- paste0(rep(unit_accumvars,each=U),seq_len(U))
     else {
       pomp_accumvars <- NULL
       unit_accumvars <- as.character(NULL)
     }
 
-    # if missing workhorses, set to default
+    ## if missing workhorses, set to default
     if (missing(rinit)) rinit <- NULL
     if (missing(rprocess) || is.null(rprocess)) {
       rprocess <- rproc_plugin()
@@ -206,16 +207,16 @@ setMethod(
 
     if (missing(params)) params <- numeric(0)
     if (is.list(params)) params <- unlist(params)
-    # Make data into a dataframe that pomp would expect
-    tmp <- 1:length(unit_names)
+    ## Make data into a dataframe that pomp would expect
+    tmp <- seq_along(unit_names)
     names(tmp) <- unit_names
     pomp_data <- data %>% dplyr::mutate(ui = tmp[match(data[,unitname], names(tmp))])
     pomp_data <- pomp_data %>% tidyr::gather(unit_obsnames, key = 'obsname', value = 'val') %>% dplyr::arrange_at(c(timename,'obsname','ui'))
     pomp_data <- pomp_data %>% dplyr::mutate(obsname = paste0(.data$obsname,.data$ui)) %>% dplyr::select(-upos) %>% dplyr::select(-.data$ui)
     pomp_data <- pomp_data %>% tidyr::spread(key = .data$obsname, value = .data$val)
     dat_col_order <- vector(length = U*length(unit_obsnames))
-    for(oti in seq(length(unit_obsnames))){
-      for(i in 1:U){
+    for(oti in seq_along(unit_obsnames)){
+      for(i in seq_len(U)){
         dat_col_order[(oti-1)*U + i] = paste0(unit_obsnames[oti], i)
       }
     }
@@ -224,11 +225,11 @@ setMethod(
       if(timename %in% names(covar)) tcovar <- timename
       else{
         stop(sQuote("covariate"), ' data.frame should have a time column with the same name as the ',
-        'time column of the observation data.frame')
+          'time column of the observation data.frame')
       }
     }
-    # make covariates into a dataframe that pomp would expect
-    unit_covarnames <- NULL # could get overwritten soon
+    ## make covariates into a dataframe that pomp would expect
+    unit_covarnames <- NULL ## could get overwritten soon
     if(missing(shared_covarnames)) shared_covarnames <- NULL
     if(!missing(covar)){
       upos_cov <- match(unitname, names(covar))
@@ -241,14 +242,14 @@ setMethod(
         cov_col_order <- c(cov_col_order, shared_covarnames)
       }
       if(length(unit_covarnames) > 0){
-        tmp <- 1:length(unit_names)
+        tmp <- seq_along(unit_names)
         names(tmp) <- unit_names
         pomp_covar <- covar %>% dplyr::mutate(ui = match(covar[,unitname], names(tmp)))
         pomp_covar <- pomp_covar %>% tidyr::gather(unit_covarnames, key = 'covname', value = 'val')
         pomp_covar <- pomp_covar %>% dplyr::mutate(covname = paste0(.data$covname,.data$ui)) %>% dplyr::select(-upos_cov) %>% dplyr::select(-.data$ui)
         pomp_covar <- pomp_covar %>% tidyr::spread(key = .data$covname, value = .data$val)
         for(cn in unit_covarnames){
-          for(i in 1:U){
+          for(i in seq_len(U)){
             cov_col_order = c(cov_col_order, paste0(cn, i))
           }
         }
@@ -261,82 +262,82 @@ setMethod(
       pomp_covar <- pomp::covariate_table()
     }
 
-    # Get all names before call to pomp().
-    if(!missing(unit_statenames)) pomp_statenames <- paste0(rep(unit_statenames,each=U),1:U)
+    ## Get all names before call to pomp().
+    if(!missing(unit_statenames)) pomp_statenames <- paste0(rep(unit_statenames,each=U),seq_len(U))
     else pomp_statenames <- NULL
-    pomp_obsnames <- paste0(rep(unit_obsnames,each=U),1:U)
     if (!missing(covar)){
-      if(missing(shared_covarnames)) pomp_covarnames <- paste0(rep(unit_covarnames,each=U),1:U)
+      if(missing(shared_covarnames)) pomp_covarnames <- paste0(rep(unit_covarnames,each=U),seq_len(U))
       else {
         if(length(unit_covarnames) == 0) pomp_covarnames <- shared_covarnames
-        else pomp_covarnames <- c(shared_covarnames, paste0(rep(unit_covarnames,each=U),1:U))
+        else pomp_covarnames <- c(shared_covarnames, paste0(rep(unit_covarnames,each=U),seq_len(U)))
       }
     }
     else pomp_covarnames <- NULL
     if (missing(paramnames)) paramnames <- NULL
     if (!missing(paramnames)) mparamnames <- paste("M_", paramnames, sep = "")
 
-    # We will always have a global giving us the number of spatial units
+    ## We will always have a global giving us the number of spatial units
     if(missing(globals)) globals <- Csnippet(paste0("const int U = ",length(unit_names),";\n"))
     else globals <- Csnippet(paste0(paste0("\nconst int U = ",length(unit_names),";\n"),globals@text))
 
-    # create the pomp object
+    ## create the pomp object
     po <- pomp(data = pomp_data,
-               times=times,
-               t0 = t0,
-               rprocess = rprocess,
-               rmeasure = rmeasure,
-               dprocess = dprocess,
-               dmeasure = dmeasure,
-               skeleton = skeleton,
-               rinit = rinit,
-               statenames=pomp_statenames,
-               accumvars=pomp_accumvars,
-               covar = pomp_covar,
-               paramnames = paramnames,
-               globals = globals,
-               cdir = cdir,
-               cfile = cfile,
-               shlib.args = shlib.args,
-               partrans = partrans,
-               ...,
-               verbose=verbose
-    )
-
-    # Hitch the spatPomp components
-    hitches <- pomp::hitch(
-      eunit_measure=eunit_measure,
-      munit_measure=munit_measure,
-      vunit_measure=vunit_measure,
-      dunit_measure=dunit_measure,
-      runit_measure=runit_measure,
-      templates=eval(spatPomp_workhorse_templates),
-      obsnames = paste0(unit_obsnames,"1"),
-      statenames = paste0(unit_statenames,"1"),
-      paramnames=paramnames,
-      covarnames=pomp_covarnames,
-      PACKAGE=PACKAGE,
-      globals=globals,
-      cfile=cfile,
-      cdir=cdir,
-      shlib.args=shlib.args,
+      times=times,
+      t0 = t0,
+      rprocess = rprocess,
+      rmeasure = rmeasure,
+      dprocess = dprocess,
+      dmeasure = dmeasure,
+      skeleton = skeleton,
+      rinit = rinit,
+      statenames=pomp_statenames,
+      accumvars=pomp_accumvars,
+      covar = pomp_covar,
+      paramnames = paramnames,
+      globals = globals,
+      cdir = cdir,
+      cfile = cfile,
+      shlib.args = shlib.args,
+      partrans = partrans,
+      ...,
       verbose=verbose
     )
 
+    ## Hitch the spatPomp components
+    hitches <- pomp::hitch(
+                       eunit_measure=eunit_measure,
+                       munit_measure=munit_measure,
+                       vunit_measure=vunit_measure,
+                       dunit_measure=dunit_measure,
+                       runit_measure=runit_measure,
+                       templates=eval(spatPomp_workhorse_templates),
+                       obsnames = paste0(unit_obsnames,"1"),
+                       statenames = paste0(unit_statenames,"1"),
+                       paramnames=paramnames,
+                       mparamnames=mparamnames,
+                       covarnames=pomp_covarnames,
+                       PACKAGE=PACKAGE,
+                       globals=globals,
+                       cfile=cfile,
+                       cdir=cdir,
+                       shlib.args=shlib.args,
+                       verbose=verbose
+                     )
+
     pomp::solibs(po) <- hitches$lib
     new("spatPomp",po,
-        eunit_measure=hitches$funs$eunit_measure,
-        munit_measure=hitches$funs$munit_measure,
-        vunit_measure=hitches$funs$vunit_measure,
-        dunit_measure=hitches$funs$dunit_measure,
-        runit_measure=hitches$funs$runit_measure,
-        unit_names=unit_names,
-        unit_statenames=unit_statenames,
-        unit_accumvars=unit_accumvars,
-        unit_obsnames=unit_obsnames,
-        unitname=unitname,
-        unit_covarnames=as.character(unit_covarnames),
-        shared_covarnames=as.character(shared_covarnames))
+      eunit_measure=hitches$funs$eunit_measure,
+      munit_measure=hitches$funs$munit_measure,
+      vunit_measure=hitches$funs$vunit_measure,
+      dunit_measure=hitches$funs$dunit_measure,
+      runit_measure=hitches$funs$runit_measure,
+      unit_names=unit_names,
+      unit_statenames=unit_statenames,
+      unit_accumvars=unit_accumvars,
+      unit_obsnames=unit_obsnames,
+      unitname=unitname,
+      unit_covarnames=as.character(unit_covarnames),
+      shared_covarnames=as.character(shared_covarnames))
   }
 )
 
@@ -344,15 +345,15 @@ setMethod(
   "construct_spatPomp",
   signature=signature(data="spatPomp", times="NULL", units="NULL"),
   definition = function (data, times, units, t0, timename, unitname, ...,
-                         rinit, rprocess, dprocess, rmeasure, dmeasure, skeleton, rprior, dprior,
-                         partrans, params, paramnames, unit_statenames, covar, shared_covarnames, unit_accumvars,
-                         dunit_measure, eunit_measure, vunit_measure, munit_measure, runit_measure,
-                         globals, verbose, PACKAGE, cfile, cdir, shlib.args) {
+    rinit, rprocess, dprocess, rmeasure, dmeasure, skeleton, rprior, dprior,
+    partrans, params, paramnames, unit_statenames, covar, shared_covarnames, unit_accumvars,
+    dunit_measure, eunit_measure, vunit_measure, munit_measure, runit_measure,
+    globals, verbose, PACKAGE, cfile, cdir, shlib.args) {
     times <- data@times
     unit_names <- data@unit_names; U <- length(unit_names)
     if(missing(unit_statenames)) unit_statenames <- data@unit_statenames
     if(length(unit_statenames) == 0) pomp_statenames <- NULL
-    else pomp_statenames <- paste0(rep(unit_statenames,each=U),1:U)
+    else pomp_statenames <- paste0(rep(unit_statenames,each=U),seq_len(U))
     unit_obsnames <- data@unit_obsnames
     if(missing(timename)) timename <- data@timename
     else timename <- as.character(timename)
@@ -366,7 +367,7 @@ setMethod(
       if(timename %in% names(covar)) tcovar <- timename
       else{
         stop(sQuote("covariate"), ' data.frame should have a time column with the same name as the ',
-                      'observation data')
+          'observation data')
       }
       upos_cov <- match(unitname, names(covar))
       tpos_cov <- match(tcovar, names(covar))
@@ -378,14 +379,14 @@ setMethod(
         cov_col_order <- c(cov_col_order, shared_covarnames)
       }
       if(length(unit_covarnames) > 0){
-        tmp <- 1:length(unit_names)
+        tmp <- seq_along(unit_names)
         names(tmp) <- unit_names
         pomp_covar <- covar %>% dplyr::mutate(ui = match(covar[,unitname], names(tmp)))
         pomp_covar <- pomp_covar %>% tidyr::gather(unit_covarnames, key = 'covname', value = 'val')
         pomp_covar <- pomp_covar %>% dplyr::mutate(covname = paste0(.data$covname,.data$ui)) %>% dplyr::select(-upos_cov) %>% dplyr::select(-.data$ui)
         pomp_covar <- pomp_covar %>% tidyr::spread(key = .data$covname, value = .data$val)
         for(cn in unit_covarnames){
-          for(i in 1:U){
+          for(i in seq_len(U)){
             cov_col_order = c(cov_col_order, paste0(cn, i))
           }
         }
@@ -419,57 +420,57 @@ setMethod(
       if (!missing(params)) paramnames <- names(params)
     }
     if (missing(unit_accumvars)) accumvars <- data@accumvars
-    .solibs <- data@solibs
 
-    # Get all names before call to hitch()
-    if (!missing(covar)) pomp_covarnames <- paste0(rep(unit_covarnames,each=U),1:U)
+    ## Get all names before call to hitch()
+    if (!missing(covar)) pomp_covarnames <- paste0(rep(unit_covarnames,each=U),seq_len(U))
     else  pomp_covarnames <- get_covariate_names(data@covar)
-    if (!missing(unit_accumvars)) pomp_accumvars <- paste0(rep(unit_accumvars,each=U),1:U)
+    if (!missing(unit_accumvars)) pomp_accumvars <- paste0(rep(unit_accumvars,each=U),seq_len(U))
     else pomp_accumvars <- data@accumvars
     mparamnames <- paste("M_", paramnames, sep = "")
 
-    # We will always have a global giving us the number of spatial units
+    ## We will always have a global giving us the number of spatial units
     if(missing(globals)) globals <- Csnippet(paste0("const int U = ",length(unit_names),";\n"))
     else globals <- Csnippet(paste0(paste0("\nconst int U = ",length(unit_names),";\n"),globals@text))
     po <- pomp(data = data,
-               t0 = t0,
-               rprocess = rprocess,
-               rmeasure = rmeasure,
-               dprocess = dprocess,
-               dmeasure = dmeasure,
-               skeleton = skeleton,
-               rinit = rinit,
-               covar = pomp_covar,
-               statenames=pomp_statenames,
-               accumvars=pomp_accumvars,
-               paramnames = paramnames,
-               globals = globals,
-               cdir = cdir,
-               cfile = cfile,
-               shlib.args = shlib.args,
-               partrans = partrans,
-               ...,
-               verbose=verbose
+      t0 = t0,
+      rprocess = rprocess,
+      rmeasure = rmeasure,
+      dprocess = dprocess,
+      dmeasure = dmeasure,
+      skeleton = skeleton,
+      rinit = rinit,
+      covar = pomp_covar,
+      statenames=pomp_statenames,
+      accumvars=pomp_accumvars,
+      paramnames = paramnames,
+      globals = globals,
+      cdir = cdir,
+      cfile = cfile,
+      shlib.args = shlib.args,
+      partrans = partrans,
+      ...,
+      verbose=verbose
     )
 
     hitches <- pomp::hitch(
-      eunit_measure=eunit_measure,
-      munit_measure=munit_measure,
-      vunit_measure=vunit_measure,
-      dunit_measure=dunit_measure,
-      runit_measure=runit_measure,
-      templates=eval(spatPomp_workhorse_templates),
-      obsnames = paste0(unit_obsnames,"1"),
-      statenames = paste0(unit_statenames,"1"),
-      paramnames=paramnames,
-      covarnames=pomp_covarnames,
-      PACKAGE=PACKAGE,
-      globals=globals,
-      cfile=cfile,
-      cdir=cdir,
-      shlib.args=shlib.args,
-      verbose=verbose
-    )
+                       eunit_measure=eunit_measure,
+                       munit_measure=munit_measure,
+                       vunit_measure=vunit_measure,
+                       dunit_measure=dunit_measure,
+                       runit_measure=runit_measure,
+                       templates=eval(spatPomp_workhorse_templates),
+                       obsnames = paste0(unit_obsnames,"1"),
+                       statenames = paste0(unit_statenames,"1"),
+                       paramnames=paramnames,
+                       mparamnames=mparamnames,
+                       covarnames=pomp_covarnames,
+                       PACKAGE=PACKAGE,
+                       globals=globals,
+                       cfile=cfile,
+                       cdir=cdir,
+                       shlib.args=shlib.args,
+                       verbose=verbose
+                     )
     pomp::solibs(po) <- hitches$lib
     new(
       "spatPomp",

--- a/R/spatPomp.R
+++ b/R/spatPomp.R
@@ -419,7 +419,7 @@ setMethod(
     } else{
       if (!missing(params)) paramnames <- names(params)
     }
-    if (missing(unit_accumvars)) accumvars <- data@accumvars
+    if (missing(unit_accumvars)) unit_accumvars <- data@accumvars
 
     ## Get all names before call to hitch()
     if (!missing(covar)) pomp_covarnames <- paste0(rep(unit_covarnames,each=U),seq_len(U))

--- a/R/vunit_measure.R
+++ b/R/vunit_measure.R
@@ -36,7 +36,7 @@ setMethod(
     pompLoad(object)
     storage.mode(x) <- "double"
     storage.mode(params) <- "double"
-    out <- .Call('do_theta_to_v',
+    out <- .Call(do_theta_to_v,
           object=object,
           X=x,
           Np = as.integer(Np),

--- a/src/iabf.c
+++ b/src/iabf.c
@@ -156,11 +156,3 @@ SEXP iabf_computations (SEXP x, SEXP params, SEXP Np,
   UNPROTECT(nprotect);
   return(retval);
 }
-
-SEXP randwalk_perturbation_spatPomp(SEXP params, SEXP rw_sd){
-  return(randwalk_perturbation_pomp(params, rw_sd));
-}
-
-SEXP lookup_in_table_spatPomp(SEXP covar, SEXP t){
-  return(lookup_in_table_pomp(covar, t));
-}

--- a/src/init.c
+++ b/src/init.c
@@ -1,7 +1,17 @@
 #include <R_ext/Rdynload.h>
 #include "spatPomp_defines.h"
 
+SEXP randwalk_perturbation_spatPomp(SEXP params, SEXP rw_sd) {
+  return(randwalk_perturbation_pomp(params, rw_sd));
+}
+
+SEXP lookup_in_table_spatPomp(SEXP covar, SEXP t) {
+  return(lookup_in_table_pomp(covar, t));
+}
+
 static const R_CallMethodDef callMethods[] = {
+  {"randwalk_perturbation_spatPomp", (DL_FUNC) &randwalk_perturbation_spatPomp,2},
+  {"lookup_in_table_spatPomp", (DL_FUNC) &lookup_in_table_spatPomp,2},
   {"do_dunit_measure", (DL_FUNC) &do_dunit_measure, 8},
   {"do_runit_measure", (DL_FUNC) &do_runit_measure, 6},
   {"abf_computations", (DL_FUNC) &abf_computations, 5},


### PR DESCRIPTION
This pull request resolves some of the existing NOTEs generated by R CMD CHECK.  In particular, there were many variables defined but not used.  I have removed these. 

In the process, I caught one coding error that had no consequences (fortuitously).  In `R/spatPomp.R`, the variable `mparamnames` was defined but not passed to `hitch` as it should have been.  Remarkably, because of the nature of the C-snippet template rendering process, the behavior was nevertheless correct.  Despite this, the connection between `mparamnames` and the templates was obscure and might be the source of confusion in future (not to mention flags at check-time).  I have corrected this.

I also uncovered one potential bug.  Specifically, in `R/spatPomp.R`, on line 421, we have
```
if (missing(unit_accumvars)) accumvars <- data@accumvars
```
The variable `accumvars`, if created, is never used.  I surmise that this line should read
```
if (missing(unit_accumvars)) unit_accumvars <- data@accumvars
```
and have made the corresponding change in the pull request.
For convenience, this is a separate commit.

When I do R CMD CHECK on my system, I get another NOTE about examples that take >5s to run.  I am not sure why the [CRAN checks page](https://cran.r-project.org/web/checks/check_results_spatPomp.html) does not show this.

To check this on your system, you will need to first install pomp v4.1 from source. 

If you do a `git diff`, you'll see a lot of differences due to changes in whitespace.  You can add the `-w` flag (i.e., `git diff -w`) to suppress these inconsequential differences.

I'd like to get pomp v 4.1 to CRAN ASAP, so it would be great if we could get this pull request integrated.  The plan would then be to upload CRAN, promising that spatPomp will be updated post haste.