### PR TITLE
Fixed simulate bug and created argument to save hidden state in bpfilter.

### DIFF
--- a/man/bpfilter.Rd
+++ b/man/bpfilter.Rd
@@ -12,6 +12,7 @@
   Np,
   block_size,
   block_list,
+  save_states,
   ...,
   verbose = getOption("verbose", FALSE)
 )
@@ -27,7 +28,10 @@ into blocks with size \code{block_size}.}
 \item{block_list}{List that specifies an exact partition of the spatial units. Each partition element, or block, is
 an integer vector of neighboring units.}
 
-\item{...}{If a \code{params} argument is specified, \code{abf} will estimate the likelihood at that parameter set instead of at \code{coef(object)}.}
+\item{save_states}{logical. If True, the state-vector for each particle and
+block is saved.}
+
+\item{\dots}{If a \code{params} argument is specified, \code{bpfilter} will estimate the likelihood at that parameter set instead of at \code{coef(object)}.}
 
 \item{verbose}{logical; if \code{TRUE}, messages updating the user on progress will be printed to the console.}
 }


### PR DESCRIPTION
In the simulate function, there was a bug when using the option format = 'data.frame'. The bug occurs when the unit-state names are nested, e.g. defining a state "VR1D" and "VR1DD". This is because the code would search for a state type for each unit, and here it would think that the state type for "VR1DD10" (the state for the 10th unit) is "VR1D" instead of "VR1DD", causing it to say the unit number is "D10", rather than "10". This bug was fixed by just using the number at the end of each statename. This of course introduces a potential bug that if a unit has a state name that ends in a number, it will not be able to accurately extract the unit number, although I think that such statenames result other bugs within the function, and therefore this naming scheme should be avoided. 

The other change involves a save_state argument in the bpfilter function. For the project I'm working on, I need access to the hidden states; this argument is a feature of pomp::pfilter, but not spatPomp::bpfilter. I just made a few minor adjustments so that the bpfilter function will now accept a save_state argument, and I implemented it in a way so as to mimic the existing implementation in the pomp package.