### PR TITLE
minor modification in function spatPomp to allow input data.frame in tibble format

### DIFF
--- a/R/spatPomp.R
+++ b/R/spatPomp.R
@@ -215,7 +215,7 @@ setMethod(
     ## Make data into a dataframe that pomp would expect
     tmp <- seq_along(unit_names)
     names(tmp) <- unit_names
-    pomp_data <- data %>% dplyr::mutate(ui = tmp[match(data[,unitname], names(tmp))])
+    pomp_data <- data %>% dplyr::mutate(ui = tmp[match(data[[unitname]], names(tmp))])
     pomp_data <- pomp_data %>% tidyr::gather(unit_obsnames, key = 'obsname', value = 'val') %>% dplyr::arrange_at(c(timename,'obsname','ui'))
     pomp_data <- pomp_data %>% dplyr::mutate(obsname = paste0(.data$obsname,.data$ui)) %>% dplyr::select(-upos) %>% dplyr::select(-.data$ui)
     pomp_data <- pomp_data %>% tidyr::spread(key = .data$obsname, value = .data$val)
@@ -249,7 +249,7 @@ setMethod(
       if(length(unit_covarnames) > 0){
         tmp <- seq_along(unit_names)
         names(tmp) <- unit_names
-        pomp_covar <- covar %>% dplyr::mutate(ui = match(covar[,unitname], names(tmp)))
+        pomp_covar <- covar %>% dplyr::mutate(ui = match(covar[[unitname]], names(tmp)))
         pomp_covar <- pomp_covar %>% tidyr::gather(unit_covarnames, key = 'covname', value = 'val')
         pomp_covar <- pomp_covar %>% dplyr::mutate(covname = paste0(.data$covname,.data$ui)) %>% dplyr::select(-upos_cov) %>% dplyr::select(-.data$ui)
         pomp_covar <- pomp_covar %>% tidyr::spread(key = .data$covname, value = .data$val)
@@ -385,7 +385,7 @@ setMethod(
       if(length(unit_covarnames) > 0){
         tmp <- seq_along(unit_names)
         names(tmp) <- unit_names
-        pomp_covar <- covar %>% dplyr::mutate(ui = match(covar[,unitname], names(tmp)))
+        pomp_covar <- covar %>% dplyr::mutate(ui = match(covar[[unitname]], names(tmp)))
         pomp_covar <- pomp_covar %>% tidyr::gather(unit_covarnames, key = 'covname', value = 'val')
         pomp_covar <- pomp_covar %>% dplyr::mutate(covname = paste0(.data$covname,.data$ui)) %>% dplyr::select(-upos_cov) %>% dplyr::select(-.data$ui)
         pomp_covar <- pomp_covar %>% tidyr::spread(key = .data$covname, value = .data$val)


### PR DESCRIPTION
Hi developpers,

I have made 3 minor modifications in the code of `spatPomp` constructor, to allow input in tidyverse tibble format. Without these changes, the `spread` function here (https://github.com/kidusasfaw/spatPomp/blob/650079052cb5dc6236d023cfe6179b162266d33f/R/spatPomp.R#L221) will not work (and results in error) because the `ui` column were all NAs from the previous step (https://github.com/kidusasfaw/spatPomp/blob/650079052cb5dc6236d023cfe6179b162266d33f/R/spatPomp.R#L218).

This fix is simple and seems unlikely to affect other functionalities. I hope you could considering including this to the package as I guess many users may use the tidyverse toolkit while preprocessing.

Best,
Haogao