### PR TITLE
remove inclusion of Rinternals.h

### DIFF
--- a/inst/include/spatPomp_defines.h
+++ b/inst/include/spatPomp_defines.h
@@ -6,7 +6,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include "pomp_defines.h"
 
 typedef void spatPomp_unit_measure_model_density (double *lik, const double *y, const double *x, const double *p, int give_log,

--- a/src/dunit_measure.c
+++ b/src/dunit_measure.c
@@ -3,7 +3,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include <R_ext/Rdynload.h>
 
 #include "spatPomp_defines.h"

--- a/src/eunit_measure.c
+++ b/src/eunit_measure.c
@@ -1,7 +1,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include <R_ext/Rdynload.h>
 #include "spatPomp_defines.h"
 #include "pomp.h"

--- a/src/fcstsampvar.c
+++ b/src/fcstsampvar.c
@@ -3,7 +3,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include <R_ext/Rdynload.h>
 
 #include "spatPomp_defines.h"

--- a/src/munit_measure.c
+++ b/src/munit_measure.c
@@ -1,7 +1,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include <R_ext/Rdynload.h>
 #include "spatPomp_defines.h"
 #include "pomp.h"

--- a/src/runit_measure.c
+++ b/src/runit_measure.c
@@ -3,7 +3,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include <R_ext/Rdynload.h>
 #include <R_ext/Arith.h>
 #include <string.h>

--- a/src/spatPomp_defines.h
+++ b/src/spatPomp_defines.h
@@ -6,7 +6,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include "pomp_defines.h"
 
 typedef void spatPomp_unit_measure_model_density (double *lik, const double *y, const double *x, const double *p, int give_log,

--- a/src/vunit_measure.c
+++ b/src/vunit_measure.c
@@ -1,7 +1,7 @@
 #include <R.h>
 #include <Rmath.h>
 #include <Rdefines.h>
-#include <Rinternals.h>
+
 #include <R_ext/Rdynload.h>
 #include "spatPomp_defines.h"
 #include "pomp.h"


### PR DESCRIPTION
It turns out that it isn't necessary to include Rinternal.h in any of our source code.  Since forthcoming changes in R will be changing Rinternals and this is already causing problems elsewhere in the pomp ecosystem, I suggest stripping out Rinternals.h inclusions.  That is what this pull request does.