### PR TITLE
fix bugs in iubf when faced unintended input

### DIFF
--- a/R/iubf.R
+++ b/R/iubf.R
@@ -214,7 +214,11 @@ iubf_ubf <- function (object,
             neighbor_u <- neighbor[1]
             neighbor_n <- neighbor[2]
             if (neighbor_n == nt)
-              log_prod_cond_dens_nt  <- log_prod_cond_dens_nt + log_cond_densities[neighbor_u, ]
+              if(Nrep_per_param==1){
+                log_prod_cond_dens_nt  <- log_prod_cond_dens_nt + log_cond_densities[neighbor_u]
+              } else {
+                log_prod_cond_dens_nt  <- log_prod_cond_dens_nt + log_cond_densities[neighbor_u, ]
+              }
             else{
               ## means prev_meas_weights was non-null, i.e. dim(prev_meas_weights)[3]>=1
               log_prod_cond_dens_not_nt <- log_prod_cond_dens_not_nt +
@@ -236,8 +240,14 @@ iubf_ubf <- function (object,
 ####### Quantile resampling
     def_resample <- which(param_resamp_log_weights > quantile(param_resamp_log_weights, 1-prop))
     length_also_resample <- Nparam - length(def_resample)
-    also_resample <- sample(def_resample, size = length_also_resample, replace = TRUE,
-      prob = rep(1, length(def_resample)))
+    if(length(def_resample) > 1){
+      also_resample <- sample(def_resample, size = length_also_resample, replace = TRUE,
+      prob = rep(1, length(def_resample))) 
+    } else if (length(def_resample) == 1){
+      also_resample <- rep(def_resample, length_also_resample)
+    } else {
+      also_resample <- seq_len(Nparam)
+    }
     resample_ixs_raw <- c(def_resample, also_resample)
     resample_ixs <- (resample_ixs_raw - 1)*Nrep_per_param
     resample_ixs <- rep(resample_ixs, each = Nrep_per_param)


### PR DESCRIPTION
Hi Developers,

Recently I have been using iubf for optimising parameters in a spatPomp model. I find some codes in the `iubf` function did not behave as expected with some particular input. Here I propose changes in a few lines in the `R/iubf.R` to fix potential bugs.

1. `log_cond_densities[neighbor_u, ]` on [this line](https://github.com/kidusasfaw/spatPomp/blob/0332b11bef06235058c3aced33baeb15350f1be3/R/iubf.R#L217) will cause "out of bounds" error when `Nrep_per_param = 1`. So I added [a check](https://github.com/Koohoko/spatPomp/blob/bef1b1e85580ca742a0d4554f1bb243ba2a7a547/R/iubf.R#L217-L221) for this, otherwise we may consider forcing `Nrep_per_param` to be greater than 1.

2. The `def_resample` on [this line](https://github.com/kidusasfaw/spatPomp/blob/0332b11bef06235058c3aced33baeb15350f1be3/R/iubf.R#L237) can result in a NULL vector (vector of length 0), if all `param_resamp_log_weights` are the same. This can happen e.g. for $t_0$, when all observations are at the initial condition and adjusting parameters does have effect on the dmeasure results. A `def_resample` of length 0 will cause error when sampling it on [this line](https://github.com/kidusasfaw/spatPomp/blob/0332b11bef06235058c3aced33baeb15350f1be3/R/iubf.R#L239). To fix this, I added [a check](https://github.com/Koohoko/spatPomp/blob/bef1b1e85580ca742a0d4554f1bb243ba2a7a547/R/iubf.R#L243-L250) testing the length of `def_resample`.

3. Still for [the same code chunk](https://github.com/Koohoko/spatPomp/blob/bef1b1e85580ca742a0d4554f1bb243ba2a7a547/R/iubf.R#L243-L250) as mention in the previous point, there is a special case need to be addressed when `length(def_resample) = 1`. The `sample` function will behave differently if the input is an integer of length 1, comparing to when usually we expect the input `def_resample` is a vector of length > 1. For example when `def_resample` equals to an index `3`, we want resampling $3$, rather than resampling ${1, 2, 3}$, for multiple times. To fix this, I added a special case for `length(def_resample) = 1` [here](https://github.com/Koohoko/spatPomp/blob/bef1b1e85580ca742a0d4554f1bb243ba2a7a547/R/iubf.R#L246C16-L246C41).

Please review if this can be helpful. Thank you so much again for this package.

Best,
Haogao